### PR TITLE
update linkml and linkml runtime versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ include = ["README.md", "src/thing_description_schema/schema", "project"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-pyyaml = "^6.0.1"
-linkml-runtime = "^1.1.24"
+linkml-runtime = "^1.8.0rc2"
 
 [tool.poetry-dynamic-versioning]
 enable = false
@@ -18,7 +17,7 @@ vcs = "git"
 style = "pep440"
 
 [tool.poetry.dev-dependencies]
-linkml = "^1.3.5"
+linkml = "^1.8.0rc2"
 mkdocs-material = "^8.2.8"
 mkdocs-mermaid2-plugin = "^0.6.0"
 schemasheets = "^0.1.14"
@@ -29,4 +28,3 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.extras]
 docs = ["linkml", "mkdocs-material"]
-


### PR DESCRIPTION
LinkML versions updated from 1.3.5 to 1.8.0rc2 and LinkML Runtime version update from 1.1.24 to 1.8.0rc2. 