### PR TITLE
Use uv instead of poetry to streamline further the usage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,23 +14,11 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
-
-      - name: Run test suite
-        run: make test
+      - name: Run the program
+        run: uv run main.py

--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,8 @@ dmypy.json
 .pyre/
 
 # Only commit the lockfile in the release branch
-poetry.lock
+uv.lock
 
 # Never commit generated files
 resources/gens/
+src/wot_thing_description_toolchain_tmp

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ This project leverages [LinkML](https://linkml.io/linkml/) for modelling the [We
 
 ## Prerequisites
 
-*  Python 3.11 or greater. [Download and install Python.](https://www.python.org/downloads/)
-* The `poetry` dependency manager. [See the poetry installation documentation for more details.](https://python-poetry.org/docs/#installing-with-pipx)
-
+The [uv](https://docs.astral.sh/uv/) package manager.
 
 ## Quick Start
 1. Clone the repository and navigate to the project directory:
@@ -23,24 +21,15 @@ This project leverages [LinkML](https://linkml.io/linkml/) for modelling the [We
 git clone https://github.com/w3c/wot-thing-description-toolchain-tmp.git
 cd wot-thing-description-toolchain-tmp
 ```
-2. Prepare a clean environment
+2. Run the script using `uv`
 ```
-python -m venv .venv
-. .venv/bin/activate
+uv run main.py -h
 ```
-
-3. Install project dependencies with `poetry`:
-```
-poetry install
-```
-
-4. View all supported commands:
-`python main.py -h`
 
 ## Usage
 The main.py script supports various options:
 ```
-main.py [-h] [-l] [-s]
+uv run main.py [-h] [-l] [-s]
 
 options:
   -h, --help            show this help message and exit
@@ -50,11 +39,11 @@ options:
 ## Examples
 Generate resources using the default schema and configuration:
 ```
-python main.py
+uv run main.py
 ```
 
 Generate documentation locally and serve it:
-`python main.py -l -s`
+`uv run main.py -l -s`
 
 #### Default Paths
 * LinkML schema: `resources/schemas/thing_description.yaml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,26 @@
-[tool.poetry]
+[project]
 name = "thing_description_schema"
-version = "0.0.0.post1.dev0+dfeaf46"
+version = "0.1.0"
 description = "Thing Description Information Model as a LinkML schema"
-authors = ["Mahda Noura <mahdanoura@gmail.com>"]
+authors = [
+    { name = "Mahda Noura", email = "mahdanoura@gmail.com" }
+]
 license = "MIT"
 readme = "README.md"
 include = ["README.md", "src/thing_description_schema/schema", "project"]
-package-mode = false
 
-[tool.poetry.dependencies]
-python = "^3.11"
-linkml-runtime = "^1.8.0rc2"
-
-[tool.poetry-dynamic-versioning]
-enable = false
-vcs = "git"
-style = "pep440"
-
-[tool.poetry.dev-dependencies]
-linkml = "^1.8.0rc2"
-mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^0.6.0"
-schemasheets = "^0.1.14"
+requires-python = ">=3.12"
+dependencies = [
+    "linkml-runtime>=1.8.1",
+    "linkml>=1.8.2",
+    "mkdocs-mermaid2-plugin>=1.1.1",
+    "mkdocs-material>=9.5.32",
+    "schemasheets>=0.3.1",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry.extras]
-docs = ["linkml", "mkdocs-material"]
+[tool.hatch.build]
+only-include = ["main.py"]


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/) can take care of fetching the right version of Python and set up a virtualenv hiding everything behind `uv run main.py`

It can be installed via multiple ways including simply downloading the binary or using a curl-setup, not requiring to already have a version of python installed.