### PR TITLE
slot_uri and class_uri adapted for json-ld context generation

### DIFF
--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -40,6 +40,8 @@ slots:
   type:
     description: >-
       DataSchema type required for the JSON-LD type definitions
+      TODO: Check, maybe the range is not a Datatype property rather pointing to classes
+    slot_uri: rdf:type
     range: DataschemaTypes
 
 classes:
@@ -51,49 +53,60 @@ classes:
       const:
         description: >-
           Provides a constant value.
+        slot_uri: jsonschema:const
         range: Any
       default:
         description: >-
           Supply a default value. The value SHOULD validate against the data schema in which it resides.
+        slot_uri: jsonschema:default
         range: Any
       unit:
         description: >-
           Provides unit information that is used, e.g., in international science, engineering, and business. 
           To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition.
+        slot_uri: schema:unitCode
       oneof:
         description: >-
           Used to ensure that the data is valid against one of the specified schemas in the array. 
           This can be used to describe multiple input or output schemas.
+        slot_uri: jsonschema:oneof
       enum:
         description: >-
           Restricted set of values provided as an array.
+        slot_uri: jsonschema:enum
         multivalued: true
         range: Any
       format:
         description: >-
           Allows validation based on a format pattern such as "date-time", "email", "uri", etc.
+        slot_uri: jsonschema:format
       propertyName:
         description: >-
           Used to store the indexing name in the parent object when this schema appears as a property of an object schema.
+        slot_uri: jsonschema:propertyName
       writeOnly:
         description: >-
           Boolean value that is a hint to indicate whether a property interaction/value is write only (=true) or not (=false).
+        slot_uri: jsonschema:writeOnly
         range: boolean
       readonly:
         description: >-
           Boolean value that is a hint to indicate whether a property interaction/value is read only (=true) or not (=false).
+        slot_uri: jsonschema:readOnly
         range: boolean
       contentEncoding:
         description: >-
-          todo
+          Specifies the encoding used to store the contents, as specified in RFC 2054. The values that are accepted: 
+          \"7bit\", \"8bit\", \"binary\", \"quoted-printable\" and \"base64\".
+        slot_uri: jsonschema:contentEncoding
       contentMediaType:
         description: >-
           Specifies the MIME type of the contents of a string value, as described in [RFC2046].
+        slot_uri: jsonschema:contentMediaType
         examples:
           - value: image/png
           - value: audio/mpeg
     slots:
-      - "@type"
       - description
       - title
       - titles
@@ -101,10 +114,12 @@ classes:
       - type
   ArraySchema:
     is_a: DataSchema
+    class_uri: jsonschema:ArraySchema
     attributes:
       items:
         description: >-
           Used to define the characteristics of an array.
+        slot_uri: jsonschema:items
         exactly_one_of:
           - range: DataSchema
           - range: DataSchema
@@ -112,72 +127,97 @@ classes:
       minItems:
         description: >-
           Defines the minimum number of items that have to be in the array.
+        slot_uri: jsonschema:minItems
         range: integer
       maxItems:
         description: >-
           Defines the maximum number of items that have to be in the array.
+        slot_uri: jsonschema:maxItems
         range: integer
   BooleanSchema:
     is_a: DataSchema
+    class_uri: jsonschema:BooleanSchema
     description: >-
-      Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type in DataSchema instances.
+      Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type 
+      in DataSchema instances.
+    slot_uri: jsonschema:BooleanSchema
   NumberSchema:
     is_a: DataSchema
+    class_uri: jsonschema:NumberSchema
     description: >-
-      Metadata describing data of type number. This Subclass is indicated by the value number assigned to type in DataSchema instances.
+      Metadata describing data of type number. This Subclass is indicated by the value number assigned to type in 
+      DataSchema instances.
     attributes:
       minimum:
         description: >-
-          Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated number or integer types.
+          Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated 
+          number or integer types.
+        slot_uri: jsonschema:minimum
         range: double
       exclusiveMinimum:
         description: >-
-          Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated number or integer types.
+          Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated 
+          number or integer types.
+        slot_uri: jsonschema:exclusiveMinimum
         range: double
       maximum:
         description: >-
-          Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated number or integer types.
+          Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated 
+          number or integer types.
+        slot_uri: jsonschema:maximum
         range: double
       exclusiveMaximum:
         description: >-
-          Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated number or integer types.
+          Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated 
+          number or integer types.
+        slot_uri: jsonschema:exclusiveMaximum
         range: double
       multipleOf:
         description: >-
-          Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.
+          Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
+          associated number or integer types.
+        slot_uri: jsonschema:multipleOf
         range: double
   IntegerSchema:
     is_a: DataSchema
+    class_uri: jsonschema:IntegerSchema
     description: >-
-      Metadata describing data of type integer. This Subclass is indicated by the value integer assigned to type in DataSchema instances.
+      Metadata describing data of type integer. This Subclass is indicated by the value integer assigned to type in 
+      DataSchema instances.
     attributes:
       minimum:
         description: >-
           Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated number
           or integer types.
+        slot_uri: jsonschema:minimum
         range: integer
       exclusiveMinimum:
         description: >-
           Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated number
           or integer types.
+        slot_uri: jsonschema:exclusiveMinimum
         range: integer
       maximum:
         description: >-
           Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated number 
           or integer types.
+        slot_uri: jsonschema:maximum
         range: integer
       exclusiveMaximum:
         description: >-
           Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated number
           or integer types.
+        slot_uri: jsonschema:exclusiveMaximum
         range: integer
       multipleof:
         description: >-
           Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
           associated number or integer types.
+        slot_uri: jsonschema:multipleOf
         range: integer
   ObjectSchema:
     is_a: DataSchema
+    class_uri: jsonschema:ObjectSchema
     description: >-
       Metadata describing data of type Object. This Subclass is indicated by the value object assigned to type in 
       DataSchema instances.
@@ -185,9 +225,11 @@ classes:
       properties:
         description: >-
           Data schema nested definitions.
+        slot_uri: jsonschema:properties
         range: DataSchema
         multivalued: true
       required:
+        slot_uri: jsonschema:required
         description: >-
           Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that 
           is to be sent (e.g. input of invokeaction, writeproperty) and what members will be definitely delivered in 
@@ -195,6 +237,7 @@ classes:
         multivalued: true
   StringSchema:
     is_a: DataSchema
+    class_uri: jsonschema:StringSchema
     description: >-
       Metadata describing data of type string. This Subclass is indicated by the value string assigned to type 
       in DataSchema instances.
@@ -202,18 +245,22 @@ classes:
       minLength:
         description: >-
           Specifies the minimum length of a string. Only applicable for associated string types.
+        slot_uri: jsonschema:minLength
         range: integer
       maxLength:
         description: >-
           Specifies the maximum length of a string. Only applicable for associated string types.
+        slot_uri: jsonschema:maxLength
         range: integer
       pattern:
         description: >-
           Provides a regular expression to express constraints of the string value. The regular expression must 
           follow the [ECMA-262] dialect.
+        slot_uri: jsonschema:pattern
       contentEncoding:
         description: >-
           Specifies the encoding used to store the contents, as specified in [RFC2045] (Section 6.1) and [RFC4648].
+        slot_uri: jsonschema:contentEncoding
         examples:
           - value: 7bit
           - value: 8bit
@@ -224,6 +271,7 @@ classes:
           - value: base64
   NullSchema:
     is_a: DataSchema
+    class_uri: jsonschema:NullSchema
     description: >-
       Metadata describing data of type null. This subclass is indicated by the value null assigned to type in DataSchema 
       instances. This Subclass describes only one acceptable value, namely null. It is important to note that null does 

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -42,7 +42,14 @@ slots:
       DataSchema type required for the JSON-LD type definitions
       TODO: Check, maybe the range is not a Datatype property rather pointing to classes
     slot_uri: rdf:type
-    range: DataschemaTypes
+    exactly_one_of:
+      - range: object
+      - range: array
+      - range: boolean
+      - range: string
+      - range: number
+      - range: integer
+      - range: null
 
 classes:
   DataSchema:
@@ -112,7 +119,7 @@ classes:
       - titles
       - descriptions
       - type
-  ArraySchema:
+  array:
     is_a: DataSchema
     class_uri: jsonschema:ArraySchema
     attributes:
@@ -134,14 +141,14 @@ classes:
           Defines the maximum number of items that have to be in the array.
         slot_uri: jsonschema:maxItems
         range: integer
-  BooleanSchema:
+  boolean:
     is_a: DataSchema
     class_uri: jsonschema:BooleanSchema
     description: >-
       Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type 
       in DataSchema instances.
     slot_uri: jsonschema:BooleanSchema
-  NumberSchema:
+  number:
     is_a: DataSchema
     class_uri: jsonschema:NumberSchema
     description: >-
@@ -178,7 +185,7 @@ classes:
           associated number or integer types.
         slot_uri: jsonschema:multipleOf
         range: double
-  IntegerSchema:
+  integer:
     is_a: DataSchema
     class_uri: jsonschema:IntegerSchema
     description: >-
@@ -215,7 +222,7 @@ classes:
           associated number or integer types.
         slot_uri: jsonschema:multipleOf
         range: integer
-  ObjectSchema:
+  object:
     is_a: DataSchema
     class_uri: jsonschema:ObjectSchema
     description: >-
@@ -235,7 +242,7 @@ classes:
           is to be sent (e.g. input of invokeaction, writeproperty) and what members will be definitely delivered in 
           the payload that is being received (e.g. output of invokeaction, readproperty).
         multivalued: true
-  StringSchema:
+  string:
     is_a: DataSchema
     class_uri: jsonschema:StringSchema
     description: >-
@@ -269,7 +276,7 @@ classes:
           - value: base16
           - value: base32
           - value: base64
-  NullSchema:
+  null:
     is_a: DataSchema
     class_uri: jsonschema:NullSchema
     description: >-
@@ -278,14 +285,3 @@ classes:
       not mean the absence of a value. It is analogous to null in JavaScript, None in Python, null in Java and nil in 
       Ruby programming languages. It can be used as part of a oneOf declaration, where it is used to indicate, that 
       the data can also be null.
-
-enums:
-  DataschemaTypes:
-    permissible_values:
-      boolean:
-      integer:
-      number:
-      string:
-      object:
-      array:
-      null:

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -37,19 +37,36 @@ imports:
   - linkml:types
 
 slots:
-  type:
+  minimum:
     description: >-
-      DataSchema type required for the JSON-LD type definitions
-      TODO: Check, maybe the range is not a Datatype property rather pointing to classes
-    slot_uri: rdf:type
-    exactly_one_of:
-      - range: object
-      - range: array
-      - range: boolean
-      - range: string
-      - range: number
-      - range: integer
-      - range: null
+      Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated number
+      or integer types.
+    slot_uri: jsonschema:minimum
+    range: Decimal
+  exclusiveMinimum:
+    description: >-
+      Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated number
+      or integer types.
+    slot_uri: jsonschema:exclusiveMinimum
+    range: Decimal
+  maximum:
+    description: >-
+      Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated 
+      number or integer types.
+    slot_uri: jsonschema:maximum
+    range: Decimal
+  exclusiveMaximum:
+    description: >-
+      Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated number
+      or integer types.
+    slot_uri: jsonschema:exclusiveMaximum
+    range: Decimal
+  multipleOf:
+    description: >-
+      Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
+      associated number or integer types.
+    slot_uri: jsonschema:multipleOf
+    range: Decimal
 
 classes:
   DataSchema:
@@ -76,7 +93,20 @@ classes:
         description: >-
           Used to ensure that the data is valid against one of the specified schemas in the array. 
           This can be used to describe multiple input or output schemas.
+        multivalued: true
         slot_uri: jsonschema:oneof
+        range: DataSchema
+      allOf:
+        description: >-
+          Used to ensure that the data is valid against all of the specified schemas in the array.
+        multivalued: true
+        slot_uri: jsonschema:allOf
+        range: DataSchema
+      anyOf:
+        description: >-
+          Used to ensure that the data is valid against any of the specified schemas in the array.
+        slot_uri: jsonschema:anyOf
+        range: DataSchema
       enum:
         description: >-
           Restricted set of values provided as an array.
@@ -113,12 +143,25 @@ classes:
         examples:
           - value: image/png
           - value: audio/mpeg
+      type:
+        description: >-
+          DataSchema type required for the JSON-LD type definitions
+          TODO: Check, maybe the range is not a Datatype property rather pointing to classes
+        slot_uri: rdf:type
+        exactly_one_of:
+          - range: object
+          - range: array
+          - range: boolean
+          - range: string
+          - range: number
+          - range: integer
+          - range: null
     slots:
       - description
       - title
       - titles
       - descriptions
-      - type
+
   array:
     is_a: DataSchema
     class_uri: jsonschema:ArraySchema
@@ -155,73 +198,24 @@ classes:
       Metadata describing data of type number. This Subclass is indicated by the value number assigned to type in 
       DataSchema instances.
     attributes:
-      minimum:
-        description: >-
-          Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated 
-          number or integer types.
-        slot_uri: jsonschema:minimum
-        range: double
-      exclusiveMinimum:
-        description: >-
-          Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated 
-          number or integer types.
-        slot_uri: jsonschema:exclusiveMinimum
-        range: double
-      maximum:
-        description: >-
-          Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated 
-          number or integer types.
-        slot_uri: jsonschema:maximum
-        range: double
-      exclusiveMaximum:
-        description: >-
-          Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated 
-          number or integer types.
-        slot_uri: jsonschema:exclusiveMaximum
-        range: double
-      multipleOf:
-        description: >-
-          Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
-          associated number or integer types.
-        slot_uri: jsonschema:multipleOf
-        range: double
+    slots:
+      - minimum
+      - maximum
+      - exclusiveMinimum
+      - exclusiveMaximum
+      - multipleOf
   integer:
     is_a: DataSchema
     class_uri: jsonschema:IntegerSchema
     description: >-
       Metadata describing data of type integer. This Subclass is indicated by the value integer assigned to type in 
       DataSchema instances.
-    attributes:
-      minimum:
-        description: >-
-          Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated number
-          or integer types.
-        slot_uri: jsonschema:minimum
-        range: integer
-      exclusiveMinimum:
-        description: >-
-          Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated number
-          or integer types.
-        slot_uri: jsonschema:exclusiveMinimum
-        range: integer
-      maximum:
-        description: >-
-          Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated number 
-          or integer types.
-        slot_uri: jsonschema:maximum
-        range: integer
-      exclusiveMaximum:
-        description: >-
-          Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated number
-          or integer types.
-        slot_uri: jsonschema:exclusiveMaximum
-        range: integer
-      multipleof:
-        description: >-
-          Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
-          associated number or integer types.
-        slot_uri: jsonschema:multipleOf
-        range: integer
+    slots:
+      - minimum
+      - maximum
+      - exclusiveMinimum
+      - exclusiveMaximum
+      - multipleOf
   object:
     is_a: DataSchema
     class_uri: jsonschema:ObjectSchema

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -30,6 +30,9 @@ prefixes:
   tm:
     prefix_prefix: tm
     prefix_reference: https://www.w3.org/2019/wot/tm#
+  rdf:
+    prefix_prefix: rdf
+    prefix_reference: http://www.w3.org/1999/02/22-rdf-syntax-ns#
 default_prefix: jsonschema
 default_range: string
 
@@ -42,31 +45,31 @@ slots:
       Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for associated number
       or integer types.
     slot_uri: jsonschema:minimum
-    range: Decimal
+    range: double
   exclusiveMinimum:
     description: >-
       Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for associated number
       or integer types.
     slot_uri: jsonschema:exclusiveMinimum
-    range: Decimal
+    range: decimal
   maximum:
     description: >-
       Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for associated 
       number or integer types.
     slot_uri: jsonschema:maximum
-    range: Decimal
+    range: decimal
   exclusiveMaximum:
     description: >-
       Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for associated number
       or integer types.
     slot_uri: jsonschema:exclusiveMaximum
-    range: Decimal
+    range: decimal
   multipleOf:
     description: >-
       Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for 
       associated number or integer types.
     slot_uri: jsonschema:multipleOf
-    range: Decimal
+    range: decimal
 
 classes:
   DataSchema:
@@ -89,13 +92,11 @@ classes:
           Provides unit information that is used, e.g., in international science, engineering, and business. 
           To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition.
         slot_uri: schema:unitCode
-      oneof:
+      oneOf:
         description: >-
           Used to ensure that the data is valid against one of the specified schemas in the array. 
           This can be used to describe multiple input or output schemas.
-        multivalued: true
-        slot_uri: jsonschema:oneof
-        range: DataSchema
+        slot_uri: jsonschema:oneOf
       allOf:
         description: >-
           Used to ensure that the data is valid against all of the specified schemas in the array.
@@ -149,20 +150,19 @@ classes:
           TODO: Check, maybe the range is not a Datatype property rather pointing to classes
         slot_uri: rdf:type
         exactly_one_of:
-          - range: object
-          - range: array
-          - range: boolean
-          - range: string
-          - range: number
-          - range: integer
-          - range: null
+          - range: arraySchema
+          - range: nullSchema
+          - range: objectSchema
+          - range: booleanSchema
+          - range: stringSchema
+          - range: numberSchema
+          - range: integerSchema
     slots:
       - description
       - title
       - titles
       - descriptions
-
-  array:
+  arraySchema:
     is_a: DataSchema
     class_uri: jsonschema:ArraySchema
     attributes:
@@ -170,10 +170,8 @@ classes:
         description: >-
           Used to define the characteristics of an array.
         slot_uri: jsonschema:items
-        exactly_one_of:
-          - range: DataSchema
-          - range: DataSchema
-            multivalued: true
+        range: DataSchema
+        multivalued: true
       minItems:
         description: >-
           Defines the minimum number of items that have to be in the array.
@@ -184,27 +182,25 @@ classes:
           Defines the maximum number of items that have to be in the array.
         slot_uri: jsonschema:maxItems
         range: integer
-  boolean:
+  booleanSchema:
     is_a: DataSchema
     class_uri: jsonschema:BooleanSchema
     description: >-
       Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type 
       in DataSchema instances.
-    slot_uri: jsonschema:BooleanSchema
-  number:
+  numberSchema:
     is_a: DataSchema
     class_uri: jsonschema:NumberSchema
     description: >-
       Metadata describing data of type number. This Subclass is indicated by the value number assigned to type in 
       DataSchema instances.
-    attributes:
     slots:
       - minimum
       - maximum
       - exclusiveMinimum
       - exclusiveMaximum
       - multipleOf
-  integer:
+  integerSchema:
     is_a: DataSchema
     class_uri: jsonschema:IntegerSchema
     description: >-
@@ -216,7 +212,7 @@ classes:
       - exclusiveMinimum
       - exclusiveMaximum
       - multipleOf
-  object:
+  objectSchema:
     is_a: DataSchema
     class_uri: jsonschema:ObjectSchema
     description: >-
@@ -236,7 +232,8 @@ classes:
           is to be sent (e.g. input of invokeaction, writeproperty) and what members will be definitely delivered in 
           the payload that is being received (e.g. output of invokeaction, readproperty).
         multivalued: true
-  string:
+  stringSchema:
+    # the name has to be changed because apparantly there is an issue with LinkML
     is_a: DataSchema
     class_uri: jsonschema:StringSchema
     description: >-
@@ -270,7 +267,7 @@ classes:
           - value: base16
           - value: base32
           - value: base64
-  null:
+  nullSchema:
     is_a: DataSchema
     class_uri: jsonschema:NullSchema
     description: >-

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -65,12 +65,9 @@ types:
     description: Description with a language tag.
     from_schema: rdf
     exact_mappings:
-    - rdf:langString
+      - rdf:langString
     base: rdf:PlainLiteral
     uri: rdf:PlainLiteral
-  languageString:
-    base: rdf:langString
-    uri: rdf:langString
     structured_pattern:
       syntax: "{text}@{tag}"
 
@@ -79,16 +76,16 @@ slots:
     description: >-
       Identifier of the Thing in form of a URI [RFC3986] (e.g., stable URI, temporary and mutable URI, 
       URI with local IP address, URN, etc.).
-    range: uriorcurie
-    slot_uri: td:id
+    range: uri
   title:
     description: >-
       Provides a human-readable title (e.g., display a text for UI representation) based on a default language.
-    range: languageString
+    range: string
     slot_uri: td:title
   titles:
     description: >-
       Provides multi-language human-readable titles (e.g., display a text for UI representation in different languages).
+    slot_uri: td:titleInLanguage
     multivalued: true
     exactly_one_of:
       - range: string
@@ -100,6 +97,7 @@ slots:
   descriptions:
     description: >- 
       Can be used to support (human-readable) information in different languages.
+    slot_uri: td:descriptionInLanguage
     multivalued: true
     inlined: true
     # currently less restrictions are applied, with further restrictions according to the json schema, the following can be partially utilized
@@ -118,12 +116,12 @@ slots:
     description: >-
       Define URI template variables according to RFC6570 as collection based on schema specifications. The individual
       variables DataSchema cannot be an ObjectSchema or an ArraySchema. TODO: range is not obvious from the ontology.
-    from_schema: td:hasUriTemplateSchema
+    slot_uri: td:hasUriTemplateSchema
     range: DataSchema
     inlined: true
     multivalued: true
   forms:
-    from_schema: td:hasForm
+    slot_uri: td:hasForm
     description: >-
       Set of form hypermedia controls that describe how an operation can be performed. Forms are serializations of
       Protocol Bindings.
@@ -160,17 +158,20 @@ classes:
   VersionInfo:
     description: >-
       Provides version information.
+    class_uri: td:versionInfo
     attributes:
       instance:
         description: >-
           Provides a version identicator of this TD instance.
+        slot_uri: td:instance
         required: true
       model:
         description: >-
           Provides a version indicator of the underlying TM.
+        class_uri: td:model
   securityDefinitionsRange:
     description: >-
-      Provides version information.
+      TODO.
     attributes:
       name:
         description: >-
@@ -208,7 +209,6 @@ classes:
       - title
       - description
       - titles
-      - type
       - uriVariables
       - forms
   PropertyAffordance:
@@ -222,6 +222,7 @@ classes:
         description: >-
           A hint that indicates whether Servients hosting the Thing and Intermediaries should probide a Protocol Binding 
           that supports the observeproperty and unobserveproperty operations for this Property.
+        slot_uri: td:isObservable
         range: boolean
   ActionAffordance:
     is_a: InteractionAffordance
@@ -234,30 +235,30 @@ classes:
         description: >-
           Signals if the action is safe (=true) or not. Used to signal if there is no internal state (cf. resource state)
           is changed when invoking an Action.
-        from_schema: td:isSafe
+        slot_uri: td:isSafe
         range: boolean
       synchronous:
         description: >-
           Indicates whether the action is synchronous (=true) or not. A synchronous action means that the response of action
           contains all the information about the result of the action and no further querying about the status of the action
           is needed. Lack of this keyword means that no claim on the synchronicity of the action can be made.
-        from_schema: td:isSynchronous
+        slot_uri: td:isSynchronous
         range: boolean
       idempotent:
         description: >-
           Indicates whether the action is idempotent (=true) or not. Informs whether the action can be called repeatedly with the same
           results, if present, based on the same input.
-        from_schema: td:isIdempotent
+        slot_uri: td:isIdempotent
         range: boolean
       input:
         description: >-
           Used to define the input data schema of the Action.
-        from_schema: td:hasInputSchema
+        slot_uri: td:hasInputSchema
         range: DataSchema
       output:
         description: >-
           Used to define the output data schema of the action.
-        from_schema: td:hasOutputSchema
+        slot_uri: td:hasOutputSchema
         range: DataSchema
   EventAffordance:
     is_a: InteractionAffordance
@@ -269,22 +270,22 @@ classes:
       subscription:
         description: >-
           Defines data that needs to be passed upon subscription, e.g., filters or message format for setting up Webhooks.
-        from_schema: td:hasSubscriptionSchema
+        slot_uri: td:hasSubscriptionSchema
         range: DataSchema
       cancellation:
         description: >-
           Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to remove a Webhook.
-        from_schema: td:hasCancellationSchema
+        slot_uri: td:hasCancellationSchema
         range: DataSchema
       data:
         description: >-
           Defines the data schema of the Event instance messages pushed by the Thing.
-        from_schema: td:hasNotificationSchema
+        slot_uri: td:hasNotificationSchema
         range: DataSchema
       dataResponse:
         description: >-
           Defines the data schema of the Event response messages sent by the consumer in a response to a data message.
-        from_schema: td:hasNotificationResponseSchema
+        slot_uri: td:hasNotificationResponseSchema
         range: DataSchema
   Thing:
     tree_root: true
@@ -302,31 +303,32 @@ classes:
       version:
         description: >- 
           Provides version information.
+        slot_uri: td:versionInfo
         range: VersionInfo
       created:
-        from_schema: dcterms
+        slot_uri: dct:created
         description: >-
           Provides information when the TD instance was created.
         range: datetime
       modified:
-        from_schema: dcterms
+        slot_uri: dct:modified
         description: >-
           Provides information when the TD instance was last modified.
         range: datetime
-      supportContact:
+      support:
         description: >-
           Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],<code>tel</code> [[RFC3966]],<code>https</code> [[RFC9112]]).
-        range: uriorcurie
-        from_schema: schema:contactPoint
+        range: uri
+        slot_uri: td:supportContact
       base:
         description: >-
           Define the base URI that is used for all relative URI references throughout a TD document.
-        from_schema: td:baseURI
-        range: uriorcurie
+        slot_uri: td:baseURI
+        range: uri
       profile:
         description: >-
           Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.
-        from_schema: td:followsProfile
+        slot_uri: td:followsProfile
         range: Any
         any_of:
           - range: uriorcurie
@@ -358,7 +360,7 @@ classes:
         multivalued: true
         range: DataSchema
       links:
-        from_schema: td:hasLink
+        slot_uri: td:hasLink
         description: >-
           Provides Web links to arbitrary resources that relate to the specified Thing Description.
         multivalued: true
@@ -419,7 +421,7 @@ enums:
       queryaction:
         description: Identifies the querying operation on Action Affordances to get the status of the corresponding action.
         meaning: td:queryAction
-      cancelaction:
+      cancellation:
         description: Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
         meaning: td:cancelAction
       subscribeevent:

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -143,15 +143,6 @@ classes:
         multivalued: true
         none_of:
           - equals_string: 'tm:ThingModel'
-  language:
-    attributes:
-      text:
-        description: >-
-          The string part of the plain literal.
-        required: true
-      tag:
-        description: The optional language tag for the plain literal.
-        range: LanguageTags
         
   # start of main classes, required for RDF generation
 

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -168,7 +168,7 @@ classes:
       model:
         description: >-
           Provides a version indicator of the underlying TM.
-        class_uri: td:model
+        slot_uri: td:model
   securityDefinitionsRange:
     description: >-
       TODO.
@@ -176,6 +176,7 @@ classes:
       name:
         description: >-
           Indexing property to store entity names when serializing them in a JSON-LD @index container.
+        slot_uri: wotsec:name
         identifier: true
       value:
         inlined: true
@@ -201,6 +202,7 @@ classes:
       name:
         description: >-
           Indexing property to store entity names when serializing them in a JSON-LD @index container.
+        slot_uri: td:name
         identifier: true
     slots:
       - "@type"
@@ -336,8 +338,8 @@ classes:
           - range: uriorcurie
       security:
         description: >-
-          A Thing may define abstract security schemes, used to configure the secure access of (a set of) affordance(s).
-        from_schema: td:definesSecurityScheme
+          A security configuration is a a security scheme applied to a (set of) affordance(s).
+        slot_uri: td:hasSecurityConfiguration
         required: true
         exactly_one_of:
           - range: string
@@ -345,9 +347,8 @@ classes:
           - range: string
       securityDefinitions:
         description: >- 
-          Set of named security configurations (definitions only). Not actually applied unless names are used in 
-          a security name-value pair.
-        from_schema: td:hasSecurityConfiguration
+          A Thing may define abstract security schemes, used to configure the secure access of (a set of) affordance(s).
+        slot_uri: td:definesSecurityScheme
         range: securityDefinitionsRange
         required: true
         minimum_cardinality: 1
@@ -357,6 +358,7 @@ classes:
         description: >- 
           TODO This has to be checked, it is not in the ontologies anywhere.
           Set of named data schemas. To be used in a schema name-value pair inside an AdditionalExpectedResponse object.
+        slot_uri: td:schemaDefinitions
         multivalued: true
         range: DataSchema
       links:
@@ -368,21 +370,21 @@ classes:
       properties:
         description: >-
           All Property-based interaction affordances of the Thing.
-        from_schema: td:hasPropertyAffordance
+        slot_uri: td:hasPropertyAffordance
         multivalued: true
         inlined: true
         range: PropertyAffordance
       actions:
         description: >-
           All Action-based interaction affordances of the Thing.
-        from_schema: td:hasActionAffordance
+        slot_uri: td:hasActionAffordance
         multivalued: true
         inlined: true
         range: ActionAffordance
       events:
         description: >-
           All Event-based interaction affordances of the Thing.
-        from_schema: td:hasEventAffordance
+        slot_uri: td:hasEventAffordance
         multivalued: true
         inlined: true
         range: EventAffordance

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -174,16 +174,15 @@ classes:
         inlined: true
         range: Any
         exactly_one_of:
-          - range: BearerSecurityScheme
-          - range: OAuth2SecurityScheme
-          - range: ComboSecurityScheme
-          - range: DigestSecurityScheme
-          - range: BasicSecurityScheme
-          - range: NoSecurityScheme
-          - range: AutoSecurityScheme
-          - range: APISecurityScheme
-          - range: PSKSecurityScheme
-          - range: APIKeySecurityScheme
+          - range: bearer
+          - range: oauth2
+          - range: combo
+          - range: digest
+          - range: basic
+          - range: nosec
+          - range: auto
+          - range: psk
+          - range: apikey
   InteractionAffordance:
     description: >-
       Metadata of a Thing that shows the possible choices to Consumers, thereby suggesting how Consumers may interact 

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -104,14 +104,15 @@ slots:
 #    exactly_one_of:
 #      - range: type_declaration_string
 #      - range: type_declaration_array
-  "@type":
-    description: >-
-      JSON-LD keyword to label the object with semantic tags (or types).
-    exactly_one_of:
-      - range: string
-      - range: string
-        multivalued: true
-    inlined: false
+
+#  "@type":
+#    description: >-
+#      JSON-LD keyword to label the object with semantic tags (or types).
+#    exactly_one_of:
+#      - range: string
+#      - range: string
+#        multivalued: true
+#    inlined: false
   uriVariables:
     description: >-
       Define URI template variables according to RFC6570 as collection based on schema specifications. The individual
@@ -196,7 +197,6 @@ classes:
         slot_uri: td:name
         identifier: true
     slots:
-      - "@type"
       - titles
       - descriptions
       - title
@@ -385,7 +385,6 @@ classes:
       - description
       - titles
       - descriptions
-      - "@type"
       - titles
       - descriptions
       - uriVariables

--- a/resources/schemas/wot_security.yaml
+++ b/resources/schemas/wot_security.yaml
@@ -60,6 +60,12 @@ classes:
       scheme:
         required: true
         range: SecuritySchemeType
+      hasInstanceConfiguration:
+        slot_uri: td:hasInstanceConfiguration
+        description: >-
+          Instantiation, as used here, is a form of non-symmetric equivalence between a scheme and a configuration: 
+          whatever statement on the scheme is also true of the configuration but not vice-versa.
+
     slots:
       - description
       - descriptions

--- a/resources/schemas/wot_security.yaml
+++ b/resources/schemas/wot_security.yaml
@@ -21,6 +21,9 @@ prefixes:
   wotsec:
     prefix_prefix: wotsec
     prefix_reference: https://www.w3.org/2019/wot/security#
+  rdf:
+    prefix_prefix: rdf
+    prefix_reference: http://www.w3.org/1999/02/22-rdf-syntax-ns#
 
 default_prefix: wotsec
 default_range: string
@@ -32,15 +35,19 @@ slots:
   name:
     description: >-
       Name for query, header, cookie, or uri parameters.
+    slot_uri: wotsec:name
   in:
     description: >-
       Specifies the location of security authentication information.
+    slot_uri: wotsec:in
     range: InHeader
   authorization:
     description: >-
       URI of the authorization server.
-    range: uriorcurie
+    slot_uri: wotsec:authorization
+    range: uri
   scheme:
+    slot_uri: rdf:type
     required: true
 
 classes:
@@ -51,12 +58,12 @@ classes:
       defined within a data-link-type Vocabulary included in the data-link-type, either in the standard Vocabulary 
       defined in TD Information Model or in a TD Context Extension.
     attributes:
-      # The @type attribute has not been added due to LinkML bug.
       proxy:
         description: >-
           URI of the proxy server this security configuration provides access to. If not given, the corresponding security configuration
           is for the endpoint.
-        range: uriorcurie
+        slot_uri: wotsec:proxy
+        range: uri
       scheme:
         required: true
         range: SecuritySchemeType
@@ -65,12 +72,10 @@ classes:
         description: >-
           Instantiation, as used here, is a form of non-symmetric equivalence between a scheme and a configuration: 
           whatever statement on the scheme is also true of the configuration but not vice-versa.
-
     slots:
       - description
       - descriptions
-      - "@type"
-  BearerSecurityScheme:
+  bearer:
     is_a: SecurityScheme
     description: >-
       Bearer token authentication security configuration identified by the term <code>bearer.  This scheme is intended 
@@ -79,18 +84,21 @@ classes:
       with RFC7519, jws indicates conformance with RFC7797, cwt indicates conformance with RFC8392, and jwe indicates 
       conformance with !RFC7516, with values for alg interpreted consistently with those standards. 
       Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions.
+    class_uri: wotsec:BearerSecurityScheme
     attributes:
       scheme:
         equals_string: bearer
       alg:
         description: >-
           Encoding, encryption, or digest algorithm.
+        slot_uri: wotsec:alg
         examples:
           - value: ES256
           - value: es512-256
       format:
         description: >-
           Specifies format of security authentication information.
+        slot_uri: wotsec:format
         examples:
           - value: jwt
           - value: cwt
@@ -100,8 +108,9 @@ classes:
       - authorization
       - name
       - in
-  OAuth2SecurityScheme:
+  oauth2:
     is_a: SecurityScheme
+    class_uri: wotsec:OAuth2SecurityScheme
     description: >-
       OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]], identified 
       by the Vocabulary Term oauth2. For the code flow both authorization and token MUST be included. For the client
@@ -114,6 +123,7 @@ classes:
       flow:
         description: >-
           Authorization flow.
+        slot_uri: wotsec:flow
         required: true
         examples:
           - value: code
@@ -121,24 +131,28 @@ classes:
       token:
         description: >-
           URI of the token server.
-        range: uriorcurie
+        slot_uri: wotsec:token
+        range: uri
       refresh:
         description: >-
           URI of the refresh server.
-        range: uriorcurie
+        slot_uri: wotsec:refresh
+        range: uri
       scopes:
         description: >-
           Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an 
           authorization server and associated with forms in order to identify what resources a client may access and how.  
           The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.
+        slot_uri: wotsec:scopes
         exactly_one_of:
           - range: string
           - range: string
             multivalued: true
     slots:
       - authorization
-  ComboSecurityScheme:
+  combo:
     is_a: SecurityScheme
+    class_uri: wotsec:ComboSecurityScheme
     description: >-
       A combination of other security schemes identified by the Vocabulary Term combo. Elements of this scheme define 
       various ways in which other named schemes defined in securityDefinitions, including other ComboSecurityScheme definitions, 
@@ -150,13 +164,16 @@ classes:
         description: >-
           Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, 
           will allow access.  Only one may be chosen for use.
+        slot_uri: wotsec:oneOf
         multivalued: true
       allOf:
         description: >-
           Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.
+        slot_uri: wotsec:allOf
         multivalued: true
-  DigestSecurityScheme:
+  digest:
     is_a: SecurityScheme
+    class_uri: wotsec:DigestSecurityScheme
     description: >-
       Digest authentication security configuration identified by the term digest. This scheme is similar to basic 
       authentication but with added features to avoid man-in-the-middle attacks.
@@ -166,14 +183,16 @@ classes:
       qop:
         description: >-
           Quality of protection
+        slot_uri: wotsec:qop
         examples:
           - value: one of auth
           - value: oath-int
     slots:
       - name
       - in
-  BasicSecurityScheme:
+  basic:
     is_a: SecurityScheme
+    class_uri: wotsec:BasicSecurityScheme
     description: >-
       Basic authentication security configuration identified by the term basic, using an unencrypted username and password.
     attributes:
@@ -182,38 +201,45 @@ classes:
     slots:
       - name
       - in
-  NoSecurityScheme:
+  nosec:
     is_a: SecurityScheme
+    class_uri: wotsec:NoSecurityScheme
     description: >-
       A security configuration corresponding to identified by the term nosec, indicating there is no authentication or 
       other mechanism required to access the resource.
     attributes:
       scheme:
         equals_string: nosec
-  AutoSecurityScheme:
+  auto:
     is_a: SecurityScheme
+    class_uri: wotsec:AutoSecurityScheme
     description: >-
       An automatic authentication security configuration identified by the term auto. 
-      This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, 
-      subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
+      This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at 
+      runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication 
+      when using HTTP).
     attributes:
       scheme:
         equals_string: auto
-  APISecurityScheme:
+  apikey:
     is_a: SecurityScheme
+    class_uri: wotsec:APIKeySecurityScheme
     description: >-
       API key authentication security configuration identified by the term apikey.  This scheme is to be used when the 
       access token is opaque, for example when a key in a proprietary format is provided by a cloud service provider.  
       In this case the key may not be using a standard token format. This scheme indicates that the key provided by the 
       service provider needs to be supplied as part of service requests using the mechanism indicated by the \"in\" field.
     attributes:
+      apiKeyIn:
+        description: >-
+          Specifies the location of security authentication information.
       scheme:
         equals_string: apikey
     slots:
       - name
-      - in
-  PSKSecurityScheme:
+  psk:
     is_a: SecurityScheme
+    class_uri: wotsec:PSKSecurityScheme
     description: >-
       Pre-shared key authentication security configuration identified by the term psk.  
       This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[rfc4279]], and that the 
@@ -224,17 +250,7 @@ classes:
       identity:
         description: >-
           Identifier providing information which can be used for selection or confirmation.
-  APIKeySecurityScheme:
-    is_a: SecurityScheme
-    description: >-
-      Pre-shared key authentication security configuration identified by the term psk.  
-      This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[rfc4279]], and that the 
-      ciphersuite used for keys will be established during protocol negotiation.
-    attributes:
-      scheme:
-        equals_string: apikey
-    slots:
-      - in
+        slot_uri: wotsec:identity
 
 enums:
   SecuritySchemeType:


### PR DESCRIPTION
The JSON-LD context requires the `@id` which points to the semantic classes, therefore this PR adds these using the LinkML concepts `class_uri` for classes and `slot_uri `for object properties. 