### PR TITLE
JSON-LD @Context postprocessing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,23 +14,11 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
-
-      - name: Run test suite
-        run: make test
+      - name: Run the program
+        run: uv run main.py

--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,8 @@ dmypy.json
 .pyre/
 
 # Only commit the lockfile in the release branch
-poetry.lock
+uv.lock
 
 # Never commit generated files
 resources/gens/
+src/wot_thing_description_toolchain_tmp

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ This project leverages [LinkML](https://linkml.io/linkml/) for modelling the [We
 
 ## Prerequisites
 
-*  Python 3.11 or greater. [Download and install Python.](https://www.python.org/downloads/)
-* The `poetry` dependency manager. [See the poetry installation documentation for more details.](https://python-poetry.org/docs/#installing-with-pipx)
-
+The [uv](https://docs.astral.sh/uv/) package manager.
 
 ## Quick Start
 1. Clone the repository and navigate to the project directory:
@@ -23,24 +21,15 @@ This project leverages [LinkML](https://linkml.io/linkml/) for modelling the [We
 git clone https://github.com/w3c/wot-thing-description-toolchain-tmp.git
 cd wot-thing-description-toolchain-tmp
 ```
-2. Prepare a clean environment
+2. Run the script using `uv`
 ```
-python -m venv .venv
-. .venv/bin/activate
+uv run main.py -h
 ```
-
-3. Install project dependencies with `poetry`:
-```
-poetry install
-```
-
-4. View all supported commands:
-`python main.py -h`
 
 ## Usage
 The main.py script supports various options:
 ```
-main.py [-h] [-l] [-s]
+uv run main.py [-h] [-l] [-s]
 
 options:
   -h, --help            show this help message and exit
@@ -50,11 +39,11 @@ options:
 ## Examples
 Generate resources using the default schema and configuration:
 ```
-python main.py
+uv run main.py
 ```
 
 Generate documentation locally and serve it:
-`python main.py -l -s`
+`uv run main.py -l -s`
 
 #### Default Paths
 * LinkML schema: `resources/schemas/thing_description.yaml`

--- a/main.py
+++ b/main.py
@@ -48,7 +48,9 @@ def post_process_jsonldcontext(schema_view: SchemaView, serialized_schema: str) 
             serialized_schema_json['@context'][slot.name]['@container'] = '@language'
             if '@type' in serialized_schema_json['@context'][slot.name]:
                 del serialized_schema_json['@context'][slot.name]['@type']
-        # if slot.slot_uri is not None and 'InLanguage' in slot.slot_uri and isinstance(serialized_schema_json['@context'][slot.name], dict):
+        if slot.in_language and isinstance(serialized_schema_json['@context'][slot.name],
+                                                                       dict):
+            serialized_schema_json['@context'][slot.name]['@language'] = slot.in_language
         if slot.inlined and slot.multivalued and not slot.inlined_as_list and isinstance(serialized_schema_json['@context'][slot.name], dict):
             serialized_schema_json['@context'][slot.name]['@container'] = '@index'
             if slot.instantiates:

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ def generate_docs():
 
 
 def post_process_jsonldcontext(schema_view: SchemaView, serialized_schema: str) -> str:
+    #Addressing JSON-LD @Container keywords that support values: [@list, @set, @language, @index, @id, @type, Null]
     serialized_schema_json = json.loads(serialized_schema)
     for slot in schema_view.all_slots().values():
         # Update JSON-LD context as a workaround for no langString support in LinkML
@@ -48,10 +49,8 @@ def post_process_jsonldcontext(schema_view: SchemaView, serialized_schema: str) 
             if '@type' in serialized_schema_json['@context'][slot.name]:
                 del serialized_schema_json['@context'][slot.name]['@type']
         # if slot.slot_uri is not None and 'InLanguage' in slot.slot_uri and isinstance(serialized_schema_json['@context'][slot.name], dict):
-            serialized_schema_json['@context'][slot.name]['@container'] = '@language'
-            if '@type' in serialized_schema_json['@context'][slot.name]:
-                del serialized_schema_json['@context'][slot.name]['@type']
-
+        if slot.inlined and isinstance(serialized_schema_json['@context'][slot.name], dict):
+            serialized_schema_json['@context'][slot.name]['@container'] = '@index'
         if slot.multivalued and str(slot.range) == 'Any' and isinstance(serialized_schema_json['@context'][slot.name], dict):
             if '@type' in serialized_schema_json['@context'][slot.name].keys():
                 del serialized_schema_json['@context'][slot.name]['@type']

--- a/main.py
+++ b/main.py
@@ -30,8 +30,8 @@ def generate_docs():
     doc_generator.serialize(directory=str(DOCDIR))
 
 
+#Addressing JSON-LD @Container keywords that support values: [@list, @set, @language, @index, @id, @type, Null]
 def post_process_jsonldcontext(schema_view: SchemaView, serialized_schema: str) -> str:
-    #Addressing JSON-LD @Container keywords that support values: [@list, @set, @language, @index, @id, @type, Null]
     serialized_schema_json = json.loads(serialized_schema)
     for slot in schema_view.all_slots().values():
         # Update JSON-LD context as a workaround for no langString support in LinkML
@@ -49,8 +49,10 @@ def post_process_jsonldcontext(schema_view: SchemaView, serialized_schema: str) 
             if '@type' in serialized_schema_json['@context'][slot.name]:
                 del serialized_schema_json['@context'][slot.name]['@type']
         # if slot.slot_uri is not None and 'InLanguage' in slot.slot_uri and isinstance(serialized_schema_json['@context'][slot.name], dict):
-        if slot.inlined and isinstance(serialized_schema_json['@context'][slot.name], dict):
+        if slot.inlined and slot.multivalued and not slot.inlined_as_list and isinstance(serialized_schema_json['@context'][slot.name], dict):
             serialized_schema_json['@context'][slot.name]['@container'] = '@index'
+            if slot.instantiates:
+                serialized_schema_json['@context'][slot.name]['@index'] = slot.instantiates
         if slot.multivalued and str(slot.range) == 'Any' and isinstance(serialized_schema_json['@context'][slot.name], dict):
             if '@type' in serialized_schema_json['@context'][slot.name].keys():
                 del serialized_schema_json['@context'][slot.name]['@type']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["README.md", "src/thing_description_schema/schema", "project"]
 requires-python = ">=3.12"
 dependencies = [
     "linkml-runtime>=1.8.2",
-    "linkml>=1.8.3",
+    "linkml>=1.8.2",
     "mkdocs-mermaid2-plugin>=1.1.1",
     "mkdocs-material>=9.5.32",
     "schemasheets>=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ include = ["README.md", "src/thing_description_schema/schema", "project"]
 
 requires-python = ">=3.12"
 dependencies = [
-    "linkml-runtime>=1.8.1",
-    "linkml>=1.8.2",
+    "linkml-runtime>=1.8.2",
+    "linkml>=1.8.3",
     "mkdocs-mermaid2-plugin>=1.1.1",
     "mkdocs-material>=9.5.32",
     "schemasheets>=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,26 @@
-[tool.poetry]
+[project]
 name = "thing_description_schema"
-version = "0.0.0.post1.dev0+dfeaf46"
+version = "0.1.0"
 description = "Thing Description Information Model as a LinkML schema"
-authors = ["Mahda Noura <mahdanoura@gmail.com>"]
+authors = [
+    { name = "Mahda Noura", email = "mahdanoura@gmail.com" }
+]
 license = "MIT"
 readme = "README.md"
 include = ["README.md", "src/thing_description_schema/schema", "project"]
-package-mode = false
 
-[tool.poetry.dependencies]
-python = "^3.11"
-linkml-runtime = "^1.8.0rc2"
-
-[tool.poetry-dynamic-versioning]
-enable = false
-vcs = "git"
-style = "pep440"
-
-[tool.poetry.dev-dependencies]
-linkml = "^1.8.0rc2"
-mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^0.6.0"
-schemasheets = "^0.1.14"
+requires-python = ">=3.12"
+dependencies = [
+    "linkml-runtime>=1.8.1",
+    "linkml>=1.8.2",
+    "mkdocs-mermaid2-plugin>=1.1.1",
+    "mkdocs-material>=9.5.32",
+    "schemasheets>=0.3.1",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry.extras]
-docs = ["linkml", "mkdocs-material"]
+[tool.hatch.build]
+only-include = ["main.py"]

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -4,6 +4,7 @@ title: hctl
 version: "1.1-11-June-2024"
 description: |-
   LinkML schema for modelling the TD Hypermedia Control information model, in particular links and forms.
+contributors: Mahda_Noura
 license: MIT
 see_also:
   - https://www.w3.org/TR/wot-thing-description11/

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -105,7 +105,7 @@ classes:
           This optional term can be used if, e.g., the output communication metadata differ from input metadata (e.g., output contentType differ from the
           input contentType). The response name contains metadata that is only valid for the response messages.
         slot_uri: hctl:returns
-        exact_mappings: :
+        exact_mappings:
           - hctl:returns
         range: ExpectedResponse
       additionalResponse:
@@ -176,10 +176,10 @@ slots:
     description: >-
       Target IRI of a link or submission target of a Form.
     slot_uri: hctl:hasTarget
-    exact_mappings:
-      - hctl:target
     required: true
     range: uri
+    exact_mappings:
+      - hctl:target
 
 enums:
   SubProtocolTypes:

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -104,7 +104,7 @@ classes:
         multivalued: true
         range: AdditionalExpectedResponse
         aliases:
-          - additional returns
+          - additionalReturns
       subprotocol:
         slot_uri: hctl:forSubProtocol
         description: >-

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -67,7 +67,6 @@ classes:
           The hreflang attribute specifies the language of a linked document. The value of this must be a valid 
           language tag [[BCP47]].
         slot_uri: hctl:hasHreflang
-
     slots:
       - href
   Form:

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -51,15 +51,10 @@ classes:
       anchor:
         description: >-
           By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.
-        range: uriorcurie
+        range: uri
       sizes:
         description: >-
           Target attribute that specifies one or more sizes for the referenced icon. Only applicable for relation type 'icon'. The value pattern follows {Height}x{Width} (e.g., \"16x16\", \"16x16 32x32\").
-      hreflang:
-        description: >-
-          The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].
-        multivalued: true
-        pattern: "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
     slots:
       - href
   Form:
@@ -177,7 +172,7 @@ slots:
     aliases:
       - target
     required: true
-    range: uriorcurie
+    range: uri
 
 enums:
   SubProtocolTypes:

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -41,21 +41,33 @@ classes:
   Link:
     class_uri: hctl:Link
     description: >-
-      A link can be viewed as a statement of the form link context that has a relation type resource at link target, where the optional target attributes may further describe the resource.
+      A link can be viewed as a statement of the form link context that has a relation type resource at link target, 
+      where the optional target attributes may further describe the resource.
     attributes:
       type:
         description: Target attribute providing a hint indicating what the media type [IANA-MEDIA-TYPES] of the result of dereferencing the link should be.
         slot_uri: hctl:hintsAtMediaType
-      relation:
+      rel:
         description: >-
           A link relation type identifies the semantics of a link.
+        slot_uri: hctl:hasRelationType
       anchor:
         description: >-
-          By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.
+          By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the 
+          representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.
+        slot_uri: hctl:hasAnchor
         range: uri
       sizes:
         description: >-
-          Target attribute that specifies one or more sizes for the referenced icon. Only applicable for relation type 'icon'. The value pattern follows {Height}x{Width} (e.g., \"16x16\", \"16x16 32x32\").
+          Target attribute that specifies one or more sizes for the referenced icon. Only applicable for relation type 
+          'icon'. The value pattern follows {Height}x{Width} (e.g., \"16x16\", \"16x16 32x32\").
+        slot_uri: hctl:hasSizes
+      hreflang:
+        description: >-
+          The hreflang attribute specifies the language of a linked document. The value of this must be a valid 
+          language tag [[BCP47]].
+        slot_uri: hctl:hasHreflang
+
     slots:
       - href
   Form:
@@ -77,12 +89,13 @@ classes:
           Content codings are primarily used to allow a representation to be compressed or otherwise usefully transformed 
           without losing the identity of its underlying media type and without loss of information. Examples of content
           coding include \"gzip\", \"deflate\", etc.
+        slot_uri: hctl:forContentCoding
       scopes:
         description: >-
-          TODO Check, was not in hctl ontology, if not could be source of discrepancy.
           Set of authorization scope identifiers provided as an array. These are provided in tokens returned by an 
           authorization server and associated with forms in order to identify what resources a client may access and how. 
           The values associated with a form SHOULD be chosen from those defined in an OAuth2SecurityScheme active on that form.
+        slot_uri: hctl:scopes
         exactly_one_of:
           - range: string
           - range: string

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -105,8 +105,8 @@ classes:
           This optional term can be used if, e.g., the output communication metadata differ from input metadata (e.g., output contentType differ from the
           input contentType). The response name contains metadata that is only valid for the response messages.
         slot_uri: hctl:returns
-        aliases:
-          - returns
+        exact_mappings: :
+          - hctl:returns
         range: ExpectedResponse
       additionalResponse:
         description: >-
@@ -116,8 +116,8 @@ classes:
         slot_uri: hctl:additionalReturns
         multivalued: true
         range: AdditionalExpectedResponse
-        aliases:
-          - additionalReturns
+        exact_mappings:
+          - hctl:additionalReturns
       subprotocol:
         slot_uri: hctl:forSubProtocol
         description: >-
@@ -176,8 +176,8 @@ slots:
     description: >-
       Target IRI of a link or submission target of a Form.
     slot_uri: hctl:hasTarget
-    aliases:
-      - target
+    exact_mappings:
+      - hctl:target
     required: true
     range: uri
 

--- a/resources/schemas/hctl.yaml
+++ b/resources/schemas/hctl.yaml
@@ -76,14 +76,6 @@ classes:
           Content codings are primarily used to allow a representation to be compressed or otherwise usefully transformed 
           without losing the identity of its underlying media type and without loss of information. Examples of content
           coding include \"gzip\", \"deflate\", etc.
-      securityDefinitions:
-        description: >-
-          Set of security definition names, chosen from those defined in securityDefinitions. These must all be satisfied for access to resources.
-        slot_uri: td:hasSecurityConfiguration
-        exactly_one_of:
-          - range: string
-          - range: string
-            multivalued: true
       scopes:
         description: >-
           TODO Check, was not in hctl ontology, if not could be source of discrepancy.
@@ -129,6 +121,7 @@ classes:
             multivalued: true
     slots:
       - href
+      - security
   ExpectedResponse:
     class_uri: hctl:ExpectedResponse
     description: >-

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -227,6 +227,7 @@ classes:
         slot_uri: jsonschema:properties
         range: DataSchema
         multivalued: true
+        inlined: true
       required:
         slot_uri: jsonschema:required
         description: >-

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -168,6 +168,8 @@ classes:
   arraySchema:
     is_a: DataSchema
     class_uri: jsonschema:ArraySchema
+    aliases:
+      - array
     attributes:
       items:
         description: >-
@@ -188,12 +190,16 @@ classes:
   booleanSchema:
     is_a: DataSchema
     class_uri: jsonschema:BooleanSchema
+    aliases:
+      - boolean
     description: >-
       Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type 
       in DataSchema instances.
   numberSchema:
     is_a: DataSchema
     class_uri: jsonschema:NumberSchema
+    aliases:
+      - number
     description: >-
       Metadata describing data of type number. This Subclass is indicated by the value number assigned to type in 
       DataSchema instances.
@@ -206,6 +212,8 @@ classes:
   integerSchema:
     is_a: DataSchema
     class_uri: jsonschema:IntegerSchema
+    aliases:
+      - integer
     description: >-
       Metadata describing data of type integer. This Subclass is indicated by the value integer assigned to type in 
       DataSchema instances.
@@ -218,6 +226,8 @@ classes:
   objectSchema:
     is_a: DataSchema
     class_uri: jsonschema:ObjectSchema
+    aliases:
+      - object
     description: >-
       Metadata describing data of type Object. This Subclass is indicated by the value object assigned to type in 
       DataSchema instances.
@@ -243,6 +253,8 @@ classes:
     # the name has to be changed because apparantly there is an issue with LinkML
     is_a: DataSchema
     class_uri: jsonschema:StringSchema
+    aliases:
+      - string
     description: >-
       Metadata describing data of type string. This Subclass is indicated by the value string assigned to type 
       in DataSchema instances.
@@ -277,6 +289,8 @@ classes:
   nullSchema:
     is_a: DataSchema
     class_uri: jsonschema:NullSchema
+    aliases:
+      - null
     description: >-
       Metadata describing data of type null. This subclass is indicated by the value null assigned to type in DataSchema 
       instances. This Subclass describes only one acceptable value, namely null. It is important to note that null does 

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -97,17 +97,19 @@ classes:
           Used to ensure that the data is valid against one of the specified schemas in the array. 
           This can be used to describe multiple input or output schemas.
         slot_uri: jsonschema:oneOf
+        multivalued: true
       allOf:
         description: >-
           Used to ensure that the data is valid against all of the specified schemas in the array.
         multivalued: true
         slot_uri: jsonschema:allOf
-        range: DataSchema
+#        range: DataSchema
       anyOf:
         description: >-
           Used to ensure that the data is valid against any of the specified schemas in the array.
         slot_uri: jsonschema:anyOf
         range: DataSchema
+        multivalued: true
       enum:
         description: >-
           Restricted set of values provided as an array.

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -153,19 +153,19 @@ classes:
           TODO: Check, maybe the range is not a Datatype property rather pointing to classes
         slot_uri: rdf:type
         exactly_one_of:
-          - range: arraySchema
-          - range: nullSchema
-          - range: objectSchema
-          - range: booleanSchema
-          - range: stringSchema
-          - range: numberSchema
-          - range: integerSchema
+          - range: ArraySchema
+          - range: NullSchema
+          - range: ObjectSchema
+          - range: BooleanSchema
+          - range: StringSchema
+          - range: NumberSchema
+          - range: IntegerSchema
     slots:
       - description
       - title
       - titles
       - descriptions
-  arraySchema:
+  ArraySchema:
     is_a: DataSchema
     class_uri: jsonschema:ArraySchema
     aliases:
@@ -187,7 +187,7 @@ classes:
           Defines the maximum number of items that have to be in the array.
         slot_uri: jsonschema:maxItems
         range: integer
-  booleanSchema:
+  BooleanSchema:
     is_a: DataSchema
     class_uri: jsonschema:BooleanSchema
     aliases:
@@ -195,7 +195,7 @@ classes:
     description: >-
       Metadata describing data of type boolean. This Subclass is indicated by the value boolean assigned to type 
       in DataSchema instances.
-  numberSchema:
+  NumberSchema:
     is_a: DataSchema
     class_uri: jsonschema:NumberSchema
     aliases:
@@ -209,7 +209,7 @@ classes:
       - exclusiveMinimum
       - exclusiveMaximum
       - multipleOf
-  integerSchema:
+  IntegerSchema:
     is_a: DataSchema
     class_uri: jsonschema:IntegerSchema
     aliases:
@@ -223,7 +223,7 @@ classes:
       - exclusiveMinimum
       - exclusiveMaximum
       - multipleOf
-  objectSchema:
+  ObjectSchema:
     is_a: DataSchema
     class_uri: jsonschema:ObjectSchema
     aliases:
@@ -249,7 +249,7 @@ classes:
           is to be sent (e.g. input of invokeaction, writeproperty) and what members will be definitely delivered in 
           the payload that is being received (e.g. output of invokeaction, readproperty).
         multivalued: true
-  stringSchema:
+  StringSchema:
     # the name has to be changed because apparantly there is an issue with LinkML
     is_a: DataSchema
     class_uri: jsonschema:StringSchema
@@ -286,7 +286,7 @@ classes:
           - value: base16
           - value: base32
           - value: base64
-  nullSchema:
+  NullSchema:
     is_a: DataSchema
     class_uri: jsonschema:NullSchema
     aliases:

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -4,6 +4,7 @@ title: jsonschema
 version: "1.1-05-July-2024"
 description: |-
   LinkML schema for modelling the TD Module for data schema specifications.
+contributors: Mahda_Noura
 license: MIT
 see_also:
   - https://www.w3.org/TR/wot-thing-description11/
@@ -226,8 +227,11 @@ classes:
           Data schema nested definitions.
         slot_uri: jsonschema:properties
         range: DataSchema
+        instantiates: propertyName
         multivalued: true
         inlined: true
+        inlined_as_list: false
+
       required:
         slot_uri: jsonschema:required
         description: >-

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -48,7 +48,7 @@ prefixes:
   tm:
     prefix_prefix: tm
     prefix_reference: https://www.w3.org/2019/wot/tm#
-default_prefix: td
+#default_prefix: td
 default_range: string
 
 imports:
@@ -150,7 +150,7 @@ classes:
 
   # start of main classes, required for RDF generation
 
-  VersionInfo:
+  versionInfo:
     description: >-
       Provides version information.
     class_uri: td:versionInfo
@@ -301,7 +301,7 @@ classes:
         description: >- 
           Provides version information.
         slot_uri: td:versionInfo
-        range: VersionInfo
+        range: versionInfo
       created:
         slot_uri: dct:created
         description: >-

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -57,16 +57,21 @@ imports:
   - jsonschema
 
 types:
-  MultiLanguage:
-    name: MultiLanguage
-    description: Description with a language tag.
-    from_schema: rdf
-    exact_mappings:
-      - rdf:langString
-    base: rdf:PlainLiteral
-    uri: rdf:PlainLiteral
-    structured_pattern:
-      syntax: "{text}@{tag}"
+  langString:
+    name: langString
+    description: A boolean flag indicating that the string could also include language tag.
+    base: Bool
+    uri: xsd:boolean
+#  MultiLanguage:
+#    name: MultiLanguage
+#    description: Description with a language tag.
+#    from_schema: rdf
+#    exact_mappings:
+#      - rdf:langString
+#    base: rdf:PlainLiteral
+#    uri: rdf:PlainLiteral
+#    structured_pattern:
+#      syntax: "{text}@{tag}"
 
 slots:
   id:
@@ -84,9 +89,7 @@ slots:
       Provides multi-language human-readable titles (e.g., display a text for UI representation in different languages).
     slot_uri: td:titleInLanguage
     multivalued: true
-    exactly_one_of:
-      - range: string
-      - range: MultiLanguage
+    range: langString
     inlined_as_list: true
   description:
     description: >-
@@ -97,6 +100,7 @@ slots:
     slot_uri: td:descriptionInLanguage
     multivalued: true
     inlined: true
+    range: langString
     # currently less restrictions are applied, with further restrictions according to the json schema, the following can be partially utilized
 #    exactly_one_of:
 #      - range: type_declaration_string

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -7,6 +7,7 @@ description: |-
   according to the W3C WoT Group (https://github.com/w3c/wot). This schema is based on LinkML and is used to generate 
   the required WoT resources e.g., JSON Schema, SHACL shapes, and RDF programmatically.
 license: MIT
+contributors: Mahda_Noura
 see_also:
   - https://www.w3.org/TR/wot-thing-description11/
 
@@ -62,16 +63,7 @@ types:
     description: A boolean flag indicating that the string could also include language tag.
     base: Bool
     uri: xsd:boolean
-#  MultiLanguage:
-#    name: MultiLanguage
-#    description: Description with a language tag.
-#    from_schema: rdf
-#    exact_mappings:
-#      - rdf:langString
-#    base: rdf:PlainLiteral
-#    uri: rdf:PlainLiteral
-#    structured_pattern:
-#      syntax: "{text}@{tag}"
+
 
 slots:
   id:
@@ -82,7 +74,7 @@ slots:
   title:
     description: >-
       Provides a human-readable title (e.g., display a text for UI representation) based on a default language.
-    range: string
+    in_language: en
     slot_uri: td:title
   titles:
     description: >-
@@ -93,6 +85,7 @@ slots:
   description:
     description: >-
       Provides additional (human-readable) information based on a default language.
+    in_language: en
   descriptions:
     description: >- 
       Can be used to support (human-readable) information in different languages.
@@ -128,7 +121,9 @@ slots:
     slot_uri: td:hasUriTemplateSchema
     range: DataSchema
     inlined: true
+    inlined_as_list: false
     multivalued: true
+    instantiates: name
   forms:
     slot_uri: td:hasForm
     description: >-
@@ -169,28 +164,28 @@ classes:
         description: >-
           Provides a version indicator of the underlying TM.
         slot_uri: td:model
-  securityDefinitionsRange:
-    description: >-
-      TODO.
-    attributes:
-      name:
-        description: >-
-          Indexing property to store entity names when serializing them in a JSON-LD @index container.
-        slot_uri: wotsec:name
-        identifier: true
-      value:
-        inlined: true
-        range: Any
-        exactly_one_of:
-          - range: bearer
-          - range: oauth2
-          - range: combo
-          - range: digest
-          - range: basic
-          - range: nosec
-          - range: auto
-          - range: psk
-          - range: apikey
+#  securityDefinitionsRange:
+#    description: >-
+#      TODO.
+#    attributes:
+#      name:
+#        description: >-
+#          Indexing property to store entity names when serializing them in a JSON-LD @index container.
+#        slot_uri: wotsec:name
+#        identifier: true
+#      value:
+#        inlined: true
+#        range: Any
+#        exactly_one_of:
+#          - range: bearer
+#          - range: oauth2
+#          - range: combo
+#          - range: digest
+#          - range: basic
+#          - range: nosec
+#          - range: auto
+#          - range: psk
+#          - range: apikey
   InteractionAffordance:
     description: >-
       Metadata of a Thing that shows the possible choices to Consumers, thereby suggesting how Consumers may interact 
@@ -338,11 +333,22 @@ classes:
         description: >- 
           A Thing may define abstract security schemes, used to configure the secure access of (a set of) affordance(s).
         slot_uri: td:definesSecurityScheme
-        range: securityDefinitionsRange
+        exactly_one_of:
+          - range: bearer
+          - range: oauth2
+          - range: combo
+          - range: digest
+          - range: basic
+          - range: nosec
+          - range: auto
+          - range: psk
+          - range: apikey
         required: true
         minimum_cardinality: 1
         inlined: true
+        inlined_as_list: false
         multivalued: true
+        instantiates: hasInstanceConfiguration
       schemaDefinitions:
         description: >- 
           TODO This has to be checked, it is not in the ontologies anywhere.
@@ -350,6 +356,8 @@ classes:
         slot_uri: td:schemaDefinitions
         multivalued: true
         range: DataSchema
+        inlined: true
+        inlined_as_list: false
       links:
         slot_uri: td:hasLink
         description: >-
@@ -362,21 +370,27 @@ classes:
         slot_uri: td:hasPropertyAffordance
         multivalued: true
         inlined: true
+        inlined_as_list: false
         range: PropertyAffordance
+        instantiates: name
       actions:
         description: >-
           All Action-based interaction affordances of the Thing.
         slot_uri: td:hasActionAffordance
         multivalued: true
         inlined: true
+        inlined_as_list: false
         range: ActionAffordance
+        instantiates: name
       events:
         description: >-
           All Event-based interaction affordances of the Thing.
         slot_uri: td:hasEventAffordance
         multivalued: true
         inlined: true
+        inlined_as_list: false
         range: EventAffordance
+        instantiates: name
     slots:
       - id
       - title

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -160,10 +160,12 @@ classes:
           Provides a version identicator of this TD instance.
         slot_uri: td:instance
         required: true
+        range: string
       model:
         description: >-
           Provides a version indicator of the underlying TM.
         slot_uri: td:model
+        range: string
 #  securityDefinitionsRange:
 #    description: >-
 #      TODO.

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -90,7 +90,6 @@ slots:
     slot_uri: td:titleInLanguage
     multivalued: true
     range: langString
-    inlined_as_list: true
   description:
     description: >-
       Provides additional (human-readable) information based on a default language.
@@ -99,7 +98,6 @@ slots:
       Can be used to support (human-readable) information in different languages.
     slot_uri: td:descriptionInLanguage
     multivalued: true
-    inlined: true
     range: langString
     # currently less restrictions are applied, with further restrictions according to the json schema, the following can be partially utilized
 #    exactly_one_of:
@@ -114,6 +112,15 @@ slots:
 #      - range: string
 #        multivalued: true
 #    inlined: false
+  security:
+    description: >-
+      A security configuration is a a security scheme applied to a (set of) affordance(s).
+    slot_uri: td:hasSecurityConfiguration
+    required: true
+    exactly_one_of:
+      - range: string
+        multivalued: true
+      - range: string
   uriVariables:
     description: >-
       Define URI template variables according to RFC6570 as collection based on schema specifications. The individual
@@ -291,7 +298,7 @@ classes:
         description: >- 
           JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
         required: true
-        range: uriorcurie
+        range: uri
         array:
       version:
         description: >- 
@@ -324,18 +331,9 @@ classes:
         slot_uri: td:followsProfile
         range: Any
         any_of:
-          - range: uriorcurie
+          - range: uri
             multivalued: true
-          - range: uriorcurie
-      security:
-        description: >-
-          A security configuration is a a security scheme applied to a (set of) affordance(s).
-        slot_uri: td:hasSecurityConfiguration
-        required: true
-        exactly_one_of:
-          - range: string
-            multivalued: true
-          - range: string
+          - range: uri
       securityDefinitions:
         description: >- 
           A Thing may define abstract security schemes, used to configure the secure access of (a set of) affordance(s).
@@ -389,6 +387,7 @@ classes:
       - descriptions
       - uriVariables
       - forms
+      - security
 
 enums:
   OperationTypes:

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -32,9 +32,6 @@ prefixes:
   rdf:
     prefix_prefix: rdf
     prefix_reference: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-  dcterms:
-    prefix_prefix: dcterms
-    prefix_reference: http://purl.org/dc/terms/
   schema:
     prefix_prefix: schema
     prefix_reference: http://schema.org/
@@ -144,7 +141,7 @@ classes:
         multivalued: true
         none_of:
           - equals_string: 'tm:ThingModel'
-        
+
   # start of main classes, required for RDF generation
 
   VersionInfo:

--- a/resources/schemas/wot_security.yaml
+++ b/resources/schemas/wot_security.yaml
@@ -4,6 +4,7 @@ title: wot_security
 version: "1.1-5-July-2024"
 description: |-
   LinkML schema for modelling the TD Security mechanisms.
+contributors: Mahda_Noura
 license: MIT
 see_also:
   - https://www.w3.org/TR/wot-thing-description11/

--- a/resources/schemas/wot_security.yaml
+++ b/resources/schemas/wot_security.yaml
@@ -67,6 +67,7 @@ classes:
         range: uri
       scheme:
         required: true
+        #if this is extra in the json schema, you can remove the range, and use induced slot
         range: SecuritySchemeType
       hasInstanceConfiguration:
         slot_uri: td:hasInstanceConfiguration
@@ -231,13 +232,11 @@ classes:
       In this case the key may not be using a standard token format. This scheme indicates that the key provided by the 
       service provider needs to be supplied as part of service requests using the mechanism indicated by the \"in\" field.
     attributes:
-      apiKeyIn:
-        description: >-
-          Specifies the location of security authentication information.
       scheme:
         equals_string: apikey
     slots:
       - name
+      - in
   psk:
     is_a: SecurityScheme
     class_uri: wotsec:PSKSecurityScheme


### PR DESCRIPTION
LinkML [JSON-LD Context generator](https://github.com/linkml/linkml/blob/main/linkml/generators/jsonldcontextgen.py) does not currently generate the `@container` keyword. The `@container` values can be `[@list, @set, @language, @indexl]`. This PR updates the LinkML schemas and addresses the limitation with post-processing. 
Also, handling default_types and exactly_one_of expressions are not supported in the generation, with post processing it is handled here.
