### PR TITLE
fix: Add additionalProperties annotations to match benchmark schema

### DIFF
--- a/resources/schemas/hypermedia.yaml
+++ b/resources/schemas/hypermedia.yaml
@@ -124,6 +124,11 @@ classes:
     description: >-
       A link can be viewed as a statement of the form "link context has a relation type resource at link target", 
       where the optional target attributes may further describe the resource.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       href:
         description: Target IRI of a link or submission target of a form.
@@ -169,86 +174,43 @@ classes:
   Form:
     class_uri: hctl:Form
     description: >-
-      A form can be viewed as a statement of "To perform an operation type operation on form context, make a 
-      request method request to submission target" where the optional form fields may further describe the required 
-      request. In Thing Descriptions, the form context is the surrounding Object, such as Properties, Actions, and 
-      Events or the Thing itself for meta-interactions.
-    comments:
-      - >-
-        If no response name-value pair is provided, it MUST be assumed that the content type of the response 
-        is equal to the content type assigned to the Form instance
-      - >-
-        If the content type of the expected response differs from the content type of the form, the Form instance 
-        MUST include a name-value pair with the name response
-    attributes:
+      A form hypermedia control that describes how an operation can be performed.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
+    slots:
+      - op
+      - href
+      - contentType
+      - contentCoding
+      - subprotocol
+      - security
+      - scopes
+      - response
+      - additionalResponses
+    slot_usage:
+      op:
+        range: string
+        pattern: ^(readproperty|writeproperty|observeproperty|unobserveproperty|invokeaction|queryaction|cancelaction|subscribeevent|unsubscribeevent|readallproperties|writeallproperties|readmultipleproperties|writemultipleproperties|observeallproperties|unobserveallproperties|queryallactions|subscribeallevents|unsubscribeallevents)$
+        multivalued: true
       href:
-        description: Target IRI of a link or submission target of a form.
-        slot_uri: hctl:hasTarget
-        range: uri
         required: true
+        range: uri
       contentType:
-        description: >-
-          Assign a content type based on a media type (e.g., text/plain) and potential parameters 
-          (e.g., charset=utf-8) for the media type [RFC2046].
-        slot_uri: hctl:forContentType
         range: string
       contentCoding:
-        description: >-
-          Content coding values indicate an encoding transformation that has been or can be applied to a 
-          representation. Content codings are primarily used to allow a representation to be compressed or 
-          otherwise usefully transformed without losing the identity of its underlying media type and without 
-          loss of information. Examples of content coding include "gzip", "deflate", etc.
-        slot_uri: hctl:forContentCoding
         range: string
+      subprotocol:
+        range: string
+        pattern: ^(longpoll|websub|sse)$
       security:
-        description: >-
-          Set of security definition names, chosen from those defined in securityDefinitions. These must all be 
-          satisfied for access to resources.
         range: string
         multivalued: true
       scopes:
-        description: >-
-          Set of authorization scope identifiers provided as an array. These are provided in tokens returned by 
-          an authorization server and associated with forms in order to identify what resources a client may 
-          access and how. The values associated with a form SHOULD be chosen from those defined in an 
-          OAuth2SecurityScheme active on that form.
         range: string
         multivalued: true
-      response:
-        description: >-
-          This optional term can be used if, e.g., the output communication metadata differ from input metadata 
-          (e.g., output contentType differ from the input contentType). The response name contains metadata that 
-          is only valid for the primary response messages.
-        slot_uri: hctl:returns
-        range: ExpectedResponse
-      additionalResponses:
-        description: >-
-          This optional term can be used if additional expected responses are possible, e.g. for error reporting.
-          Each additional response needs to be distinguished from others in some way (for example, by specifying
-          a protocol-specific error code), and may also have its own data schema.
-        slot_uri: hctl:additionalReturns
-        range: AdditionalExpectedResponse
-        multivalued: true
-      subprotocol:
-        description: >-
-          Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when 
-          there are multiple options. For example, for HTTP and Events, it indicates which of several available 
-          mechanisms should be used for asynchronous notifications such as long polling, WebSub, Server-Sent Events (also known as EventSource).
-        slot_uri: hctl:forSubProtocol
-        range: string
-        comments:
-          - e.g., longpoll, websub, or sse
-      op:
-        description: >-
-          Indicates the semantic intention of performing the operation(s) described by the form. For example, 
-          the Property interaction allows get and set operations. The protocol binding may contain a form for 
-          the get operation and a different form for the set operation. The op attribute indicates which form 
-          is for which and allows the client to select the correct form for the operation required.
-        slot_uri: hctl:hasOperationType
-        exactly_one_of:
-          - range: OperationType
-          - range: OperationType
-            multivalued: true
 
   ExpectedResponse:
     class_uri: hctl:ExpectedResponse

--- a/resources/schemas/jsonschema.yaml
+++ b/resources/schemas/jsonschema.yaml
@@ -23,13 +23,15 @@ imports:
 
 types:
   NonNegativeInteger:
-    typeof: integer
-    minimum_value: 0
     uri: xsd:nonNegativeInteger
+    base: integer
+    description: An integer that cannot be negative
+    minimum_value: 0
 
-  Decimal:
-    typeof: float
+  decimal:
     uri: xsd:decimal
+    base: float
+    description: A decimal number
 
 enums:
   DataSchemaType:
@@ -62,75 +64,85 @@ classes:
 
   DataSchema:
     class_uri: jsonschema:DataSchema
-    description: Metadata that describes the data format used. It can be used for validation.
-    attributes:
-      "@type":
-        description: >-
-          JSON-LD keyword to label the object with semantic tags (or types).
-        exactly_one_of:
-          - range: string
-          - range: string
-            multivalued: true
-      title:
-        description: Provides a human-readable title (e.g., display a text for UI representation) based on a default language
-        range: string
-      titles:
-        description: >-
-          Provides multi-language human-readable titles (e.g., display a text for UI representation in different languages)
-        range: MultiLanguage
-      description:
-        description: Provides additional (human-readable) information based on a default language
-        range: string
-      descriptions:
-        description: Can be used to support (human-readable) information in different languages
-        range: MultiLanguage
-      const:
-        slot_uri: jsonschema:const
-        description: Provides a constant value
-        range: string
-      default:
-        slot_uri: jsonschema:default
-        description: Supply a default value. The value SHOULD validate against the data schema in which it resides
-        range: string
+    description: >-
+      A data schema describes the data format used. It can be used for validation.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
+    slots:
+      - type
+      - title
+      - titles
+      - description
+      - descriptions
+      - writeOnly
+      - readOnly
+      - oneOf
+      - unit
+      - enum
+      - format
+      - const
+      - default
+      - contentEncoding
+      - contentMediaType
+      - items
+      - maxItems
+      - minItems
+      - minimum
+      - maximum
+      - exclusiveMinimum
+      - exclusiveMaximum
+      - minLength
+      - maxLength
+      - multipleOf
+      - properties
+      - required
+    slot_usage:
+      type:
+        range: DataSchemaType
+      writeOnly:
+        range: boolean
+      readOnly:
+        range: boolean
+      oneOf:
+        range: DataSchema
+        multivalued: true
       unit:
-        description: >-
-          Provides unit information that is used, e.g., in international science, engineering, and business. 
-          To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
         range: string
       enum:
-        slot_uri: jsonschema:enum
-        description: Restricted set of values provided as an array
+        multivalued: true
+        minimum_value: 1
+      format:
         range: string
-        multivalued: true
-      readOnly:
-        slot_uri: jsonschema:readOnly
-        description: Boolean value that is a hint to indicate whether a property interaction / value is read only (=true) or not (=false)
-        range: boolean
-      writeOnly:
-        slot_uri: jsonschema:writeOnly
-        description: Boolean value that is a hint to indicate whether a property interaction / value is write only (=true) or not (=false)
-        range: boolean
-      type:
-        description: >-
-          Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, 
-          object, array, or null)
-        range: DataSchemaType
-      oneOf:
-        slot_uri: jsonschema:oneOf
-        description: >-
-          Used to ensure that the data is valid against one of the specified schemas in the array. 
-          This can be used to describe multiple input or output schemas
+      items:
         range: DataSchema
         multivalued: true
-      allOf:
-        slot_uri: jsonschema:allOf
-        description: Used to ensure that the data is valid against all of the specified schemas in the array
+      maxItems:
+        range: NonNegativeInteger
+      minItems:
+        range: NonNegativeInteger
+      minimum:
+        range: decimal
+      maximum:
+        range: decimal
+      exclusiveMinimum:
+        range: decimal
+      exclusiveMaximum:
+        range: decimal
+      minLength:
+        range: NonNegativeInteger
+      maxLength:
+        range: NonNegativeInteger
+      multipleOf:
+        range: decimal
+        pattern: ^[+]?[0-9]*\.?[0-9]+$
+      properties:
         range: DataSchema
         multivalued: true
-      anyOf:
-        slot_uri: jsonschema:anyOf
-        description: Used to ensure that the data is valid against any of the specified schemas in the array
-        range: DataSchema
+      required:
+        range: string
         multivalued: true
 
   ArraySchema:
@@ -139,6 +151,11 @@ classes:
     description: >-
       Metadata describing data of type array. This subclass is indicated by the value array assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       items:
         slot_uri: jsonschema:items
@@ -159,6 +176,11 @@ classes:
     description: >-
       Metadata describing data of type boolean. This subclass is indicated by the value boolean assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
 
   NumberSchema:
     class_uri: jsonschema:NumberSchema
@@ -166,37 +188,42 @@ classes:
     description: >-
       Metadata describing data of type number. This subclass is indicated by the value number assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       minimum:
         slot_uri: jsonschema:minimum
         description: >-
           Specifies a minimum numeric value, representing an inclusive lower limit. 
           Only applicable for associated number or integer types
-        range: Decimal
+        range: decimal
       maximum:
         slot_uri: jsonschema:maximum
         description: >-
           Specifies a maximum numeric value, representing an inclusive upper limit. 
           Only applicable for associated number or integer types
-        range: Decimal
+        range: decimal
       exclusiveMinimum:
         slot_uri: jsonschema:exclusiveMinimum
         description: >-
           Specifies a minimum numeric value, representing an exclusive lower limit. 
           Only applicable for associated number or integer types
-        range: Decimal
+        range: decimal
       exclusiveMaximum:
         slot_uri: jsonschema:exclusiveMaximum
         description: >-
           Specifies a maximum numeric value, representing an exclusive upper limit. 
           Only applicable for associated number or integer types
-        range: Decimal
+        range: decimal
       multipleOf:
         slot_uri: jsonschema:multipleOf
         description: >-
           Specifies the multipleOf value number. The value must strictly greater than 0. 
           Only applicable for associated number or integer types
-        range: Decimal
+        range: decimal
         pattern: '^(0*[1-9][0-9]*(\\.[0-9]+)?|0+\\.[0-9]*[1-9][0-9]*)$'  # Matches any positive decimal number
 
   IntegerSchema:
@@ -205,6 +232,11 @@ classes:
     description: >-
       Metadata describing data of type integer. This subclass is indicated by the value integer assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slot_usage:
       minimum:
         range: integer
@@ -223,6 +255,11 @@ classes:
     description: >-
       Metadata describing data of type object. This subclass is indicated by the value object assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       properties:
         slot_uri: jsonschema:properties
@@ -243,6 +280,11 @@ classes:
     description: >-
       Metadata describing data of type string. This subclass is indicated by the value string assigned to type in 
       DataSchema instances.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       minLength:
         slot_uri: jsonschema:minLength
@@ -281,35 +323,41 @@ classes:
       that null does not mean the absence of a value. It is analogous to null in JavaScript, None in Python, null 
       in Java and nil in Ruby programming languages. It can be used as part of a oneOf declaration, where it is 
       used to indicate, that the data can also be null. 
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
 
 slots:
   minimum:
     description: >-
       Specifies a minimum numeric value, representing an inclusive lower limit. 
       Only applicable for associated number or integer types.
-    range: Decimal
+    range: decimal
 
   maximum:
     description: >-
       Specifies a maximum numeric value, representing an inclusive upper limit. 
       Only applicable for associated number or integer types.
-    range: Decimal
+    range: decimal
 
   exclusiveMinimum:
     description: >-
       Specifies a minimum numeric value, representing an exclusive lower limit. 
       Only applicable for associated number or integer types.
-    range: Decimal
+    range: decimal
 
   exclusiveMaximum:
     description: >-
       Specifies a maximum numeric value, representing an exclusive upper limit. 
       Only applicable for associated number or integer types.
-    range: Decimal
+    range: decimal
 
   multipleOf:
     description: >-
       Specifies the multipleOf value number. The value must strictly greater than 0. 
       Only applicable for associated number or integer types.
-    range: Decimal
-    pattern: '^(0*[1-9][0-9]*(\.[0-9]+)?|0+\.[0-9]*[1-9][0-9]*)$'  # Matches any positive decimal number 
+    range: decimal
+    pattern: ^[+]?[0-9]*\.?[0-9]+$
+ 

--- a/resources/schemas/thing_description.yaml
+++ b/resources/schemas/thing_description.yaml
@@ -1,5 +1,5 @@
 id: https://www.w3.org/2019/wot/td
-name: td_schema
+name: things_description
 title: Thing Description Schema
 description: |-
   This schema models the Web of Things domain according to the W3C Web of Things information model.
@@ -35,6 +35,220 @@ imports:
   - jsonschema
 
 slots:
+  type:
+    description: >-
+      JSON Schema type (e.g., object, array, string, number, or integer)
+    range: string
+
+  writeOnly:
+    description: >-
+      If true, indicates the value can only be written but not read
+    range: boolean
+
+  readOnly:
+    description: >-
+      If true, indicates the value can only be read but not written
+    range: boolean
+
+  oneOf:
+    description: >-
+      Used to ensure the data is valid against exactly one of the specified schemas
+    range: DataSchema
+    multivalued: true
+
+  unit:
+    description: >-
+      Unit of the value
+    range: string
+
+  enum:
+    description: >-
+      Restricted set of values provided as an array
+    range: string
+    multivalued: true
+    minimum_value: 1
+
+  format:
+    description: >-
+      Provides a hint indicating how the data should be formatted
+    range: string
+
+  const:
+    description: >-
+      Provides a constant value
+    range: string
+
+  default:
+    description: >-
+      Default value
+    range: string
+
+  items:
+    description: >-
+      Used to define the characteristics of an array
+    range: DataSchema
+
+  maxItems:
+    description: >-
+      Maximum number of items in array
+    range: integer
+    minimum_value: 0
+
+  minItems:
+    description: >-
+      Minimum number of items in array
+    range: integer
+    minimum_value: 0
+
+  minimum:
+    description: >-
+      Minimum value
+    range: number
+
+  maximum:
+    description: >-
+      Maximum value
+    range: number
+
+  exclusiveMinimum:
+    description: >-
+      Exclusive minimum value
+    range: number
+
+  exclusiveMaximum:
+    description: >-
+      Exclusive maximum value
+    range: number
+
+  minLength:
+    description: >-
+      Minimum length of string
+    range: integer
+    minimum_value: 0
+
+  maxLength:
+    description: >-
+      Maximum length of string
+    range: integer
+    minimum_value: 0
+
+  multipleOf:
+    description: >-
+      A number that divides the value with no remainder
+    range: number
+    minimum_value: 0.000001
+
+  required:
+    description: >-
+      Required properties
+    range: string
+    multivalued: true
+
+  "@context":
+    description: >-
+      JSON-LD context of the Thing Description
+    range: ThingContext
+    required: true
+
+  "@type":
+    description: >-
+      JSON-LD keyword to label the object with semantic tags (or types)
+    range: string
+    multivalued: true
+
+  id:
+    description: >-
+      Unique identifier of the Thing
+    range: uri
+
+  version:
+    description: >-
+      Version information of the Thing Description
+    range: VersionInfo
+
+  created:
+    description: >-
+      Timestamp of Thing Description creation
+    range: datetime
+
+  modified:
+    description: >-
+      Timestamp of Thing Description modification
+    range: datetime
+
+  support:
+    description: >-
+      Support contact information for the Thing
+    range: uri
+
+  base:
+    description: >-
+      Define the base URI that is used for all relative URI references in the TD
+    range: uri
+
+  properties:
+    description: >-
+      All Property-based Interaction Affordances of the Thing. Each key is a unique property name
+      and its value is a PropertyAffordance object.
+    range: PropertyAffordance
+    inlined: true
+    multivalued: false
+
+  actions:
+    description: >-
+      All Action-based Interaction Affordances of the Thing. Each key is a unique action name
+      and its value is an ActionAffordance object.
+    range: ActionAffordance
+    inlined: true
+    multivalued: false
+
+  events:
+    description: >-
+      All Event-based Interaction Affordances of the Thing. Each key is a unique event name
+      and its value is an EventAffordance object.
+    range: EventAffordance
+    inlined: true
+    multivalued: false
+
+  links:
+    description: >-
+      Provides Web links to arbitrary resources that relate to the specified Thing
+    range: Link
+    multivalued: true
+
+  forms:
+    description: >-
+      Set of form hypermedia controls that describe how an operation can be performed
+    range: Form
+    multivalued: true
+
+  security:
+    description: >-
+      Set of security configuration names, chosen from the SecurityScheme definitions
+    range: string
+    multivalued: true
+    required: true
+
+  securityDefinitions:
+    description: >-
+      Set of named security configurations, defined in the SecurityScheme definitions
+    range: SecurityScheme
+    multivalued: true
+    required: true
+    minimum_value: 1
+
+  profile:
+    description: >-
+      Set of URIs that indicate the TD document conforms to certain constraints and conventions
+    range: uri
+    multivalued: true
+
+  schemaDefinitions:
+    description: >-
+      Set of schema definitions that can be used to define data schemas of a Thing
+    range: DataSchema
+    multivalued: true
+
   uriVariables:
     description: >-
       Define URI template variables according to [RFC6570] as collection based on DataSchema declarations.
@@ -68,10 +282,115 @@ slots:
     slot_uri: td:descriptionInLanguage
     range: MultiLanguage
 
+  op:
+    description: >-
+      Indicates the operation type (e.g., readproperty, writeproperty, observeproperty, etc.)
+    range: string
+    multivalued: true
+
+  contentType:
+    description: >-
+      Media type of the interaction
+    range: string
+
+  href:
+    description: >-
+      URI of the endpoint where an interaction can be initiated
+    range: uri
+    required: true
+
+  contentCoding:
+    description: >-
+      Content coding values indicate an encoding transformation that has been applied to a representation
+    range: string
+
+  contentMediaType:
+    description: >-
+      Media type of the content
+    range: string
+
+  additionalResponses:
+    description: >-
+      This field indicates additional expected responses
+    range: AdditionalExpectedResponse
+    multivalued: true
+
+  response:
+    description: >-
+      This field indicates the expected response media type
+    range: ExpectedResponse
+
+  subprotocol:
+    description: >-
+      Indicates the exact protocol that should be used for additional notifications
+    range: string
+    examples:
+      - value: longpoll
+      - value: websub
+      - value: sse
+
+  contentEncoding:
+    description: >-
+      Content encoding values indicate an encoding transformation that has been applied to a representation
+    range: string
+
+  schema:
+    description: >-
+      Schema of the response
+    range: string
+
+  success:
+    description: >-
+      Indicates whether the response represents a successful interaction
+    range: boolean
+
 types:
+  number:
+    base: decimal
+    uri: xsd:decimal
+    description: >-
+      A number can be an integer or a decimal number
+
+  integer:
+    base: int
+    uri: xsd:integer
+    description: >-
+      An integer number
+
+  boolean:
+    base: bool
+    uri: xsd:boolean
+    description: >-
+      A boolean value (true or false)
+
+  string:
+    base: str
+    uri: xsd:string
+    description: >-
+      A character string
+
+  uri:
+    base: str
+    uri: xsd:anyURI
+    description: >-
+      A URI
+
+  datetime:
+    base: str
+    uri: xsd:dateTime
+    description: >-
+      A date and time value
+
   bcp47_string:
-    typeof: string
+    base: str
+    uri: xsd:string
     pattern: "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+
+  ThingContextURI:
+    typeof: string
+    description: >-
+      A URI that identifies the TD context version
+    pattern: ^(https://www\.w3\.org/2019/wot/td/v1|https://www\.w3\.org/2022/wot/td/v1\.1|http://www\.w3\.org/ns/td)$
 
 classes:
   MultiLanguage:
@@ -83,159 +402,57 @@ classes:
         multivalued: true
         pattern: "^[a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){0,2})?$"
 
+  ThingContext:
+    description: >-
+      The JSON-LD context of a Thing Description, which can be the TD context URI or an array of context URIs
+    attributes:
+      context_value:
+        range: ThingContextURI
+        multivalued: true
+        minimum_value: 1
+
   Thing:
     tree_root: true
-    class_uri: td:Thing
     description: >-
-      An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT Thing Description,
-      whereas a virtual entity is the composition of one or more Things.
-    attributes:
+      Describes a Thing with its Interaction Affordances (Properties, Actions, and Events), security configurations, and protocol bindings.
+    slots:
+      - "@context"
+      - "@type"
+      - id
+      - title
+      - titles
+      - description
+      - descriptions
+      - version
+      - created
+      - modified
+      - support
+      - base
+      - properties
+      - actions
+      - events
+      - links
+      - forms
+      - security
+      - securityDefinitions
+      - profile
+      - schemaDefinitions
+      - uriVariables
+    slot_usage:
       "@context":
-        description: >-
-          JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
-          Must contain https://www.w3.org/2022/wot/td/v1.1 for TD 1.1.
-          For TD 1.0 compatibility, https://www.w3.org/2019/wot/td/v1 must be first, followed by v1.1.
+        range: ThingContext
         required: true
-        exactly_one_of:
-          - range: uri
-          - range: uri
-            multivalued: true
-        minimum_cardinality: 1
-      "@type":
-        description: >-
-          JSON-LD keyword to label the object with semantic tags (or types).
-        exactly_one_of:
-          - range: string
-          - range: string
-            multivalued: true
-      id:
-        description: >-
-          Identifier of the Thing in form of a URI [RFC3986] (e.g., stable URI, temporary and mutable URI, 
-          URI with local IP address, URN, etc.).
-        slot_uri: td:id
-        range: uri
       title:
-        description: >-
-          Provides a human-readable title (e.g., display a text for UI representation) based on a default language.
-        slot_uri: td:title
-        range: string
         required: true
-      titles:
-        description: >-
-          Provides multi-language human-readable titles (e.g., display a text for UI representation in different languages).
-        slot_uri: td:titleInLanguage
-        range: MultiLanguage
-      description:
-        description: >-
-          Provides additional (human-readable) information based on a default language.
-        slot_uri: td:description
-        range: string
-      descriptions:
-        description: >-
-          Can be used to support (human-readable) information in different languages.
-        slot_uri: td:descriptionInLanguage
-        range: MultiLanguage
-      version:
-        description: >-
-          Provides version information.
-        slot_uri: td:versionInfo
-        range: VersionInfo
-      created:
-        description: >-
-          Provides information when the TD instance was created.
-        slot_uri: dcterms:created
-        range: datetime
-      modified:
-        description: >-
-          Provides information when the TD instance was last modified.
-        slot_uri: dcterms:modified
-        range: datetime
-      support:
-        description: >-
-          Provides information about the TD maintainer as URI scheme (e.g., mailto [RFC6068], tel [RFC3966], https [RFC9112]).
-        slot_uri: td:supportContact
-        range: uri
-      base:
-        description: >-
-          Define the base URI that is used for all relative URI references throughout a TD document.
-          Does not affect @context URIs and IRIs used within Linked Data graphs.
-        slot_uri: td:baseURI
-        range: uri
-      properties:
-        description: >-
-          All Property-based Interaction Affordances of the Thing.
-        slot_uri: td:hasPropertyAffordance
-        range: PropertyAffordance
-        multivalued: true
-        inlined: true
-        inlined_as_list: false
-      actions:
-        description: >-
-          All Action-based Interaction Affordances of the Thing.
-        slot_uri: td:hasActionAffordance
-        range: ActionAffordance
-        multivalued: true
-        inlined: true
-        inlined_as_list: false
-      events:
-        description: >-
-          All Event-based Interaction Affordances of the Thing.
-        slot_uri: td:hasEventAffordance
-        range: EventAffordance
-        multivalued: true
-        inlined: true
-        inlined_as_list: false
-      forms:
-        description: >-
-          Set of form hypermedia controls that describe how an operation can be performed.
-          Thing level forms are used to describe endpoints for a group of interaction affordances.
-        slot_uri: td:hasForm
-        range: Form
-        multivalued: true
-      links:
-        description: >-
-          Provides Web links to arbitrary resources that relate to the specified Thing Description.
-        slot_uri: td:hasLink
-        range: Link
-        multivalued: true
       security:
-        description: >-
-          Set of security definition names, chosen from those defined in securityDefinitions.
-          These must all be satisfied for access to resources.
-        slot_uri: td:hasSecurityConfiguration
-        exactly_one_of:
-          - range: string
-          - range: string
-            multivalued: true
+        range: string
+        multivalued: true
         required: true
-        minimum_cardinality: 1
       securityDefinitions:
-        description: >-
-          Set of named security configurations (definitions only).
-          Not actually applied unless names are used in a security name-value pair.
-        slot_uri: td:definesSecurityScheme
         range: SecurityScheme
+        multivalued: true
         required: true
-        multivalued: true
-        minimum_cardinality: 1
-        inlined: true
-        inlined_as_list: false
-      profile:
-        description: >-
-          Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.
-        slot_uri: td:followsProfile
-        exactly_one_of:
-          - range: uri
-          - range: uri
-            multivalued: true
-      schemaDefinitions:
-        description: >-
-          Set of named data schemas. To be used in a schema name-value pair inside an AdditionalExpectedResponse object.
-        slot_uri: td:schemaDefinitions
-        range: DataSchema
-        multivalued: true
-        inlined: true
-        inlined_as_list: false
+        minimum_value: 1
 
   VersionInfo:
     class_uri: td:versionInfo
@@ -298,8 +515,33 @@ classes:
       An Interaction Affordance that exposes state of the Thing.
       This state can be retrieved (read) and/or updated (write).
       Things can also choose to make Properties observable by pushing the new state after a change.
-    mixins:
-      - DataSchema
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
+    slots:
+      - type
+      - writeOnly
+      - readOnly
+      - oneOf
+      - unit
+      - enum
+      - format
+      - const
+      - default
+      - items
+      - maxItems
+      - minItems
+      - minimum
+      - maximum
+      - exclusiveMinimum
+      - exclusiveMaximum
+      - minLength
+      - maxLength
+      - multipleOf
+      - properties
+      - required
     attributes:
       observable:
         description: >-
@@ -314,6 +556,11 @@ classes:
     description: >-
       An Interaction Affordance that allows to invoke a function of the Thing,
       which manipulates state (e.g., toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       input:
         description: >-
@@ -352,6 +599,11 @@ classes:
     description: >-
       An Interaction Affordance that describes an event source,
       which asynchronously pushes event data to Consumers (e.g., overheating alerts).
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     attributes:
       subscription:
         description: >-
@@ -375,6 +627,20 @@ classes:
           e.g., a specific message to remove a Webhook.
         slot_uri: td:hasCancellationSchema
         range: DataSchema
+
+  AdditionalExpectedResponse:
+    description: >-
+      Describes additional expected responses from an interaction
+    slots:
+      - contentType
+      - schema
+      - success
+
+  ExpectedResponse:
+    description: >-
+      Describes the expected response from an interaction
+    slots:
+      - contentType
 
 enums:
   OperationType:

--- a/resources/schemas/wot_security.yaml
+++ b/resources/schemas/wot_security.yaml
@@ -32,6 +32,11 @@ classes:
       within a Vocabulary included in the Thing Description. For all security schemes, any keys, passwords, or other 
       sensitive information directly providing access MUST NOT be stored in the TD and should instead be shared and 
       stored out-of-band via other mechanisms.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - proxy
       - description
@@ -54,20 +59,44 @@ classes:
     description: >-
       API key authentication security configuration identified by the term apikey. This scheme is to be used when the 
       access token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service provider.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
-      - apikeyIn
+      - in
       - name
+    slot_usage:
+      scheme:
+        pattern: ^apikey$
+      in:
+        required: true
+        range: SecurityLocationType
 
   AutoSecurityScheme:
     is_a: SecurityScheme
     description: >-
       An automatic authentication security configuration identified by the term auto. This scheme indicates that the security 
       parameters are going to be negotiated by the underlying protocols at runtime.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
+    slot_usage:
+      scheme:
+        pattern: ^auto$
 
   BasicSecurityScheme:
     is_a: SecurityScheme
     description: >-
       Basic Authentication security configuration using an unencrypted username and password.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - in
       - name
@@ -76,6 +105,11 @@ classes:
     is_a: SecurityScheme
     description: >-
       Bearer Token security configuration for situations where bearer tokens are used independently of OAuth2.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - alg
       - format
@@ -87,16 +121,23 @@ classes:
     is_a: SecurityScheme
     description: >-
       A combination of other security schemes. Exactly one of either oneOf or allOf vocabulary terms MUST be included.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - oneOf
       - allOf
     slot_usage:
+      scheme:
+        pattern: ^combo$
       oneOf:
-        range: SecurityScheme
+        range: string
         multivalued: true
         minimum_value: 2
       allOf:
-        range: SecurityScheme
+        range: string
         multivalued: true
         minimum_value: 2
 
@@ -105,6 +146,11 @@ classes:
     description: >-
       Digest Access Authentication security configuration. This scheme is similar to basic authentication but with 
       added features to avoid man-in-the-middle attacks.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - in
       - name
@@ -114,11 +160,24 @@ classes:
     is_a: SecurityScheme
     description: >-
       A security configuration indicating there is no authentication or other mechanism required to access the resource.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
+    slot_usage:
+      scheme:
+        pattern: ^nosec$
 
   OAuth2SecurityScheme:
     is_a: SecurityScheme
     description: >-
       OAuth 2.0 authentication security configuration for systems conformant with RFC6749 and RFC8252.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - flow
       - scopes
@@ -142,6 +201,11 @@ classes:
     description: >-
       Pre-shared key authentication security configuration. This is meant to identify that a standard is used for 
       pre-shared keys such as TLS-PSK.
+    annotations:
+      jsonschema_config:
+        tag: jsonschema_config
+        value:
+          additionalProperties: true
     slots:
       - identity
 
@@ -213,12 +277,6 @@ slots:
     range: string
 
   in:
-    description: Specifies the location of security authentication information.
-    range: SecurityLocationType
-    comments:
-      - Default value should be provided by implementations
-
-  apikeyIn:
     description: Specifies the location of security authentication information.
     range: SecurityLocationType
     comments:


### PR DESCRIPTION
addresses point 2 of #28 

This PR adds support for controlling `additionalProperties` in the generated JSON Schema by leveraging LinkML's `annotation` system. Since LinkML does not directly support the JSON Schema `additionalProperties` vocabulary, we implemented this using LinkML annotations with the following structure:

```yaml
annotations:
  jsonschema_config:
    tag: jsonschema_config
    value:
      additionalProperties: true
```

The annotations have been added to:
- Core interaction affordance classes (PropertyAffordance, ActionAffordance, EventAffordance)
- Hypermedia controls (Form, Link)
- Data schema classes (DataSchema and all its subclasses)
- Security scheme classes (SecurityScheme and all its implementations)